### PR TITLE
Don't check XML files

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -130,7 +130,7 @@ function local_codechecker_clean_path($path) {
  * @param string $extensions File extensions to include (not including .)
  */
 function local_codechecker_find_other_files(&$arr, $folder,
-        $extensions = array('txt', 'html', 'xml', 'csv')) {
+        $extensions = array('txt', 'html', 'csv')) {
     $regex = '~\.(' . implode('|', $extensions) . ')$~';
 
     // Handle if this is called directly with a file and not folder


### PR DESCRIPTION
install.xml files are automatically generated, so no point checking them.

Some plugins want to include sample data in XML files that can be imported if you want (e.g. https://github.com/sangwinc/moodle-qtype_stack/tree/master/samplequestions) checking those gives spurious errors.

The only XML files we might want to check are environment.xml and thirdpartlibs.xml, but really, I don't think that is necessary.
