### PR TITLE
minor bug fixes to work with phpcs 2.2.0

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -30,7 +30,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends Generic_Sniff
      *
      * @var array(string => array(string => int|string|null))
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                         'call_user_method' => array(
                                             '5.3' => false,
                                             '5.4' => false,

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -30,7 +30,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends Generic_Sniffs_PHP_F
      *
      * @var array(string => array(string => int|string|null))
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                         'array_fill_keys' => array(
                                             '5.1' => false,
                                             '5.2' => true

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -25,7 +25,7 @@
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
     <rule ref="Squiz.Classes.SelfMemberReference"/>
 
-    <rule ref="Squiz.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>


### PR DESCRIPTION
A few minor bug fixes to make the ruleset compatible with PHPCS version 2.2.0.