### PR TITLE
CONTRIB-6025 phpdoc: Allow type-hinting

### DIFF
--- a/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
+++ b/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
@@ -77,3 +77,19 @@ echo 'hello'; // A--------------.
 // just checking multilines do work ok.
 /// And the correct problems are detected, also this 3-slash line
 // missig upper at the start and missing dot at the end
+
+// Following CONTRIB-6025, let's accept phpdoc type hinting matching with begin of next line.
+/** @var some_class $variable */
+$variable = $giveme->some_class();
+
+foreach ($somearray as $variable) {
+    /** @var some_class $variable */
+    $variable->do_something();
+}
+
+// Don't accept type hinting if it does not match the begin of next line.
+/** @var some_class $variable */
+lets_execute_it($variable->do_something());
+
+/** @var some_class $variable */
+$variables = $giveme->some_class();

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -55,7 +55,9 @@ class moodlestandard_testcase extends local_codechecker_testcase {
            28 => 'Inline doc block comments are not allowed; use "// Comment." instead',
            44 => 1,
            73 => 'Perl-style comments are not allowed; use "// Comment." instead',
-           78 => '3 slashes comments are not allowed'));
+           78 => '3 slashes comments are not allowed',
+           91 => '\'$variable\' does not match next code line \'lets_execute_it...\'',
+           94 => 1));
         $this->set_warnings(array(
             4 => 0,
             6 => array(null, 'Commenting.InlineComment.InvalidEndChar'),


### PR DESCRIPTION
When some inline phpdoc is found, it's verified if
it's being used to define the variable type used
in the next line of code. If next line of code
does not match, an error is returned (TypeHintingMatch).