### PR TITLE
CONTRIB-6025 phpdoc: Allow type-hinting for list() assignments

### DIFF
--- a/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
+++ b/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
@@ -93,3 +93,11 @@ lets_execute_it($variable->do_something());
 
 /** @var some_class $variable */
 $variables = $giveme->some_class();
+
+// And also, CONTRIB-6105, consider assignments via list() like a viable use.
+/** @var cm_info $cm */
+list($course, $cm) = get_course_and_cm_from_cmid($cmid);
+
+// But not this (non matching within the list().
+/** @var cm_info $cm */
+list($course, $something) = $cm->whatever($cmid);

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -57,7 +57,8 @@ class moodlestandard_testcase extends local_codechecker_testcase {
            73 => 'Perl-style comments are not allowed; use "// Comment." instead',
            78 => '3 slashes comments are not allowed',
            91 => '\'$variable\' does not match next code line \'lets_execute_it...\'',
-           94 => 1));
+           94 => 1,
+          102 => '\'$cm\' does not match next list() variables @Source: moodle.Commenting.InlineComment.TypeHintingList'));
         $this->set_warnings(array(
             4 => 0,
             6 => array(null, 'Commenting.InlineComment.InvalidEndChar'),


### PR DESCRIPTION
Now @var phpdoc blocks are also allowed if next line is a list()
statement with any of the variables being the documented one.