### PR TITLE
MDLSITE-4197 backticks: Allow them in lang strings (valid Markdown)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Changes in version 2.5.2 (2016MMDD) - giveme a name!
+----------------------------------------------------
+- MDLSITE-4197: Allow backticks within lang strings. Valid Markdown.
+
 Changes in version 2.5.1 (20160214) - Valentinius release!
 ----------------------------------------------------------
 - Pull request #19. Minor changes to make it work with CS 2.x (Corey Wallis).

--- a/moodle/tests/fixtures/moodle_strings_forbiddenstrings.php
+++ b/moodle/tests/fixtures/moodle_strings_forbiddenstrings.php
@@ -28,4 +28,12 @@ $regexp = preg_replace('/test/me0', 'ignore anything having invalid (not "imsxeA
 echo '       <div class="fp-restrictions">';
 echo '{"foo" : {"fe" : 1} }';
 
+// And these are valid lang string using Markdown formatting.
+$string['something_desc'] = 'Some with `backticks` is not so bad';
+$string['something_help'] = 'Some with `backticks` is not so bad';
+
+// But not these.
+$variable['something_desc'] = 'Some with `backticks` in this context is bad';
+$string['something_warn'] = 'Some with `backticks` in this context is bad';
+
 // Fair enough.

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -233,7 +233,9 @@ class moodlestandard_testcase extends local_codechecker_testcase {
         $this->set_warnings(array(
             19 => array('backticks in strings is not recommended'),
             20 => 1,
-            23 => 1));
+            23 => 1,
+            36 => 'backticks in strings',
+            37 => 1));
 
         // Let's do all the hard work!
         $this->verify_cs_results();


### PR DESCRIPTION
Not much to say. It looks for `$string['xxxxxx(_desc|_help)` to allow the backticks.

Already installed in the laptop, it's covered with tests and seems to be working (can try it against `lang/en/plugin.php`, previously failing).

Ciao :-)