### PR TITLE
Indentation problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@ Changes in version 2.5.3 (201604XX) - Another dent to indent
 ------------------------------------------------------------
 - NOBUG: Add travis support (using the nice [moodle-plugin-ci](https://github.com/moodlerooms/moodle-plugin-ci)
       assistant for Moodle plugins).
-- NOBUG: Upgrade PHP_CodeSniffer to 2.6.0 version.
+- NOBUG: Upgrade PHP_CodeSniffer to 2.6.0 version. (Mark Nielsen)
+- CONTRIB-5921: Exclude yui/amd and fixtures by default. (Brendan Heywood)
+- CONTRIB-6206: Fixed indentation issues when mixing functions and arrays. Bundled PHP_CodeSniffer upgraded to 2.6.2 dev version.
 - ...
 
 Changes in version 2.5.2 (20160314) - The March begins...

--- a/moodle/tests/fixtures/generic_whitespace_scopeindent.php
+++ b/moodle/tests/fixtures/generic_whitespace_scopeindent.php
@@ -136,3 +136,41 @@ echo $OUTPUT->essential_blocks('side-pre', 'row-fluid', 'aside', 4);
 <?php require_once(\theme_essential\toolbox::get_tile_file('footer')); ?>
 </body>
 </html>
+
+<?php
+
+// Now we are going to try a number of crazily nested indentations, mixing
+// both functions and arrays, to verify that CONTRIB-6206 does not break again.
+
+$somevariable = some_function(another_function($param1, $param2),
+        more_function($param3, another_one(
+                $key1, $value1,
+                $key2, $value2)));
+$continue = this_line_is_correct_and_works_ok();
+
+$somevariable = some_function(another_function($param1, $param2),
+        more_function($param3, array(
+                $key1, $value1,
+                $key2, $value2)));
+$continue = this_line_is_correct_and_works_ok();
+
+function read_competency_framework($id) {
+    global $PAGE;
+
+    $params = self::validate_parameters(self::read_competency_framework_parameters(),
+                                        array(
+                                            'id' => $id,
+                                        ));
+
+    $framework = api::read_framework($params['id']);
+}
+
+if ($showcompleted) {
+    $feedbackcompleted = $DB->get_record('feedback_completed',
+            array('feedback' => $feedback->id, 'id' => $showcompleted,
+                'anonymous_response' => FEEDBACK_ANONYMOUS_YES), '*', MUST_EXIST);
+    $responsetitle = get_string('response_nr', 'feedback') . ': ' .
+        $feedbackcompleted->random_response . ' (' . get_string('anonymous', 'feedback') . ')';
+}
+
+// End of function/array fixtures (CONTRIB-6206).

--- a/pear/PHP/CodeSniffer.php
+++ b/pear/PHP/CodeSniffer.php
@@ -73,7 +73,7 @@ class PHP_CodeSniffer
      *
      * @var string
      */
-    const VERSION = '2.6.0';
+    const VERSION = '2.6.2';
 
     /**
      * Package stability; either stable, beta or alpha.
@@ -857,10 +857,17 @@ class PHP_CodeSniffer
             // Change the directory so all relative paths are worked
             // out based on the location of the ruleset instead of
             // the location of the user.
-            $currentDir = getcwd();
-            chdir($rulesetDir);
+            $inPhar = self::isPharFile($rulesetDir);
+            if ($inPhar === false) {
+                $currentDir = getcwd();
+                chdir($rulesetDir);
+            }
+
             $this->cli->setCommandLineValues($cliArgs);
-            chdir($currentDir);
+
+            if ($inPhar === false) {
+                chdir($currentDir);
+            }
         }
 
         // Process custom ignore pattern rules.

--- a/pear/PHP/CodeSniffer/CLI.php
+++ b/pear/PHP/CodeSniffer/CLI.php
@@ -14,11 +14,13 @@
 
 error_reporting(E_ALL | E_STRICT);
 
-// Installations via Composer: make sure that we autoload all dependencies.
-if (file_exists($a = dirname(__FILE__).'/../../../autoload.php') === true) {
-    include_once $a;
-} else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php') === true) {
-    include_once $a;
+// Make sure that we autoload all dependencies if running via Composer.
+if (version_compare(PHP_VERSION, '5.3.2', '>=') === true) {
+    if (file_exists($a = dirname(__FILE__).'/../../../autoload.php') === true) {
+        include_once $a;
+    } else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php') === true) {
+        include_once $a;
+    }
 }
 
 if (file_exists($a = dirname(__FILE__).'/../CodeSniffer.php') === true) {
@@ -243,7 +245,7 @@ class PHP_CodeSniffer_CLI
     public function checkRequirements()
     {
         // Check the PHP version.
-        if (version_compare(PHP_VERSION, '5.1.2') === -1) {
+        if (version_compare(PHP_VERSION, '5.1.2', '<') === true) {
             echo 'ERROR: PHP_CodeSniffer requires PHP version 5.1.2 or greater.'.PHP_EOL;
             exit(2);
         }
@@ -379,8 +381,6 @@ class PHP_CodeSniffer_CLI
         if (empty($this->values) === false) {
             return $this->values;
         }
-
-        $values = $this->getDefaults();
 
         $args = $_SERVER['argv'];
         array_shift($args);
@@ -1079,7 +1079,7 @@ class PHP_CodeSniffer_CLI
                 $standard = 'PEAR';
             }
 
-            return array($standard);
+            return explode(',', $standard);
         }//end if
 
         $cleaned   = array();
@@ -1334,7 +1334,7 @@ class PHP_CodeSniffer_CLI
      * @param int $width The width of the report. If "auto" then will
      *                   be replaced by the terminal width.
      *
-     * @return void
+     * @return int
      */
     private function _validateReportWidth($width)
     {

--- a/pear/PHP/CodeSniffer/File.php
+++ b/pear/PHP/CodeSniffer/File.php
@@ -993,7 +993,6 @@ class PHP_CodeSniffer_File
         // Work out which sniff generated the error.
         if (substr($code, 0, 9) === 'Internal.') {
             // Any internal message.
-            $sniff     = $code;
             $sniffCode = $code;
         } else {
             $parts = explode('_', str_replace('\\', '_', $this->_activeListener));
@@ -1141,7 +1140,6 @@ class PHP_CodeSniffer_File
         // Work out which sniff generated the warning.
         if (substr($code, 0, 9) === 'Internal.') {
             // Any internal message.
-            $sniff     = $code;
             $sniffCode = $code;
         } else {
             $parts = explode('_', str_replace('\\', '_', $this->_activeListener));
@@ -1763,6 +1761,13 @@ class PHP_CodeSniffer_File
             }//end switch
         }//end for
 
+        // Cleanup for any openers that we didn't find closers for.
+        // This typically means there was a syntax error breaking things.
+        foreach ($openers as $opener) {
+            unset($tokens[$opener]['parenthesis_opener']);
+            unset($tokens[$opener]['parenthesis_owner']);
+        }
+
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             echo "\t*** END TOKEN MAP ***".PHP_EOL;
         }
@@ -1829,10 +1834,6 @@ class PHP_CodeSniffer_File
     {
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             echo "\t*** START SCOPE MAP ***".PHP_EOL;
-            $isWin = false;
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-                $isWin = true;
-            }
         }
 
         $numTokens = count($tokens);
@@ -1896,11 +1897,6 @@ class PHP_CodeSniffer_File
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
             echo str_repeat("\t", $depth);
             echo "=> Begin scope map recursion at token $stackPtr with depth $depth".PHP_EOL;
-
-            $isWin = false;
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-                $isWin = true;
-            }
         }
 
         $opener    = null;
@@ -3402,11 +3398,12 @@ class PHP_CodeSniffer_File
     /**
      * Returns the position of the first non-whitespace token in a statement.
      *
-     * @param int $start The position to start searching from in the token stack.
+     * @param int       $start  The position to start searching from in the token stack.
+     * @param int|array $ignore Token types that should not be considered stop points.
      *
      * @return int
      */
-    public function findStartOfStatement($start)
+    public function findStartOfStatement($start, $ignore=null)
     {
         $endTokens = PHP_CodeSniffer_Tokens::$blockOpeners;
 
@@ -3417,6 +3414,15 @@ class PHP_CodeSniffer_File
         $endTokens[T_OPEN_TAG]         = true;
         $endTokens[T_CLOSE_TAG]        = true;
         $endTokens[T_OPEN_SHORT_ARRAY] = true;
+
+        if ($ignore !== null) {
+            $ignore = (array) $ignore;
+            foreach ($ignore as $code) {
+                if (isset($endTokens[$code]) === true) {
+                    unset($endTokens[$code]);
+                }
+            }
+        }
 
         $lastNotEmpty = $start;
 
@@ -3457,11 +3463,12 @@ class PHP_CodeSniffer_File
     /**
      * Returns the position of the last non-whitespace token in a statement.
      *
-     * @param int $start The position to start searching from in the token stack.
+     * @param int       $start  The position to start searching from in the token stack.
+     * @param int|array $ignore Token types that should not be considered stop points.
      *
      * @return int
      */
-    public function findEndOfStatement($start)
+    public function findEndOfStatement($start, $ignore=null)
     {
         $endTokens = array(
                       T_COLON                => true,
@@ -3475,6 +3482,15 @@ class PHP_CodeSniffer_File
                       T_OPEN_TAG             => true,
                       T_CLOSE_TAG            => true,
                      );
+
+        if ($ignore !== null) {
+            $ignore = (array) $ignore;
+            foreach ($ignore as $code) {
+                if (isset($endTokens[$code]) === true) {
+                    unset($endTokens[$code]);
+                }
+            }
+        }
 
         $lastNotEmpty = $start;
 

--- a/pear/PHP/CodeSniffer/Fixer.php
+++ b/pear/PHP/CodeSniffer/Fixer.php
@@ -428,6 +428,41 @@ class PHP_CodeSniffer_Fixer
 
 
     /**
+     * Stop recording actions for a changeset, and discard logged changes.
+     *
+     * @return void
+     */
+    public function rollbackChangeset()
+    {
+        $this->_inChangeset = false;
+        $this->_inConflict  = false;
+
+        if (empty($this->_changeset) === false) {
+            if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                $bt = debug_backtrace();
+                if ($bt[1]['class'] === 'PHP_CodeSniffer_Fixer') {
+                    $sniff = $bt[2]['class'];
+                    $line  = $bt[1]['line'];
+                } else {
+                    $sniff = $bt[1]['class'];
+                    $line  = $bt[0]['line'];
+                }
+
+                $numChanges = count($this->_changeset);
+
+                @ob_end_clean();
+                echo "\t\tR: $sniff (line $line) rolled back the changeset ($numChanges changes)".PHP_EOL;
+                echo "\t=> Changeset rolled back".PHP_EOL;
+                ob_start();
+            }
+
+            $this->_changeset = array();
+        }//end if
+
+    }//end rollbackChangeset()
+
+
+    /**
      * Replace the entire contents of a token.
      *
      * @param int    $stackPtr The position of the token in the token stack.

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -140,6 +140,7 @@ class Generic_Sniffs_Functions_CallTimePassByReferenceSniff implements PHP_CodeS
                 $tokenCode = $tokens[$tokenBefore]['code'];
                 if ($tokenCode === T_VARIABLE
                     || $tokenCode === T_CLOSE_PARENTHESIS
+                    || $tokenCode === T_CLOSE_SQUARE_BRACKET
                     || $tokenCode === T_LNUMBER
                     || isset(PHP_CodeSniffer_Tokens::$assignmentTokens[$tokenCode]) === true
                 ) {

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -107,8 +107,9 @@ class Generic_Sniffs_Functions_OpeningFunctionBraceKernighanRitchieSniff impleme
             $error = 'Opening brace should be on the same line as the declaration';
             $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'BraceOnNewLine');
             if ($fix === true) {
+                $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($openingBrace - 1), $closeBracket, true);
                 $phpcsFile->fixer->beginChangeset();
-                $phpcsFile->fixer->addContent($closeBracket, ' {');
+                $phpcsFile->fixer->addContent($prev, ' {');
                 $phpcsFile->fixer->replaceToken($openingBrace, '');
                 $phpcsFile->fixer->endChangeset();
             }

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -253,87 +253,146 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
 
                 $parenOpener = $tokens[$parenCloser]['parenthesis_opener'];
                 if ($tokens[$parenCloser]['line'] !== $tokens[$parenOpener]['line']) {
-                    $first       = $phpcsFile->findFirstOnLine(T_WHITESPACE, $parenOpener, true);
-                    $checkIndent = ($tokens[$first]['column'] - 1);
-                    if (isset($adjustments[$first]) === true) {
-                        $checkIndent += $adjustments[$first];
+                    $parens = 0;
+                    if (isset($tokens[$parenCloser]['nested_parenthesis']) === true
+                        && empty($tokens[$parenCloser]['nested_parenthesis']) === false
+                    ) {
+                        end($tokens[$parenCloser]['nested_parenthesis']);
+                        $parens = key($tokens[$parenCloser]['nested_parenthesis']);
+                        if ($this->_debug === true) {
+                            $line = $tokens[$parens]['line'];
+                            echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
+                        }
+                    }
+
+                    $condition = 0;
+                    if (isset($tokens[$parenCloser]['conditions']) === true
+                        && empty($tokens[$parenCloser]['conditions']) === false
+                    ) {
+                        end($tokens[$parenCloser]['conditions']);
+                        $condition = key($tokens[$parenCloser]['conditions']);
+                        if ($this->_debug === true) {
+                            $line = $tokens[$condition]['line'];
+                            $type = $tokens[$condition]['type'];
+                            echo "\t* token is inside condition $condition ($type) on line $line *".PHP_EOL;
+                        }
+                    }
+
+                    if ($parens > $condition) {
+                        if ($this->_debug === true) {
+                            echo "\t* using parenthesis *".PHP_EOL;
+                        }
+
+                        $parenOpener = $parens;
+                        $condition   = 0;
+                    } else if ($condition > 0) {
+                        if ($this->_debug === true) {
+                            echo "\t* using condition *".PHP_EOL;
+                        }
+
+                        $parenOpener = $condition;
+                        $parens      = 0;
                     }
 
                     $exact = false;
 
-                    if ($this->_debug === true) {
-                        $line = $tokens[$first]['line'];
-                        $type = $tokens[$first]['type'];
-                        echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
-                    }
-
-                    if ($first === $tokens[$parenCloser]['parenthesis_opener']) {
-                        // This is unlikely to be the start of the statement, so look
-                        // back further to find it.
-                        $first--;
-                    }
-
-                    $prev = $phpcsFile->findStartOfStatement($first);
-                    if ($prev !== $first) {
-                        // This is not the start of the statement.
-                        if ($this->_debug === true) {
-                            $line = $tokens[$prev]['line'];
-                            $type = $tokens[$prev]['type'];
-                            echo "\t* previous is $type on line $line *".PHP_EOL;
+                    if ($condition > 0
+                        && isset($tokens[$condition]['scope_opener']) === true
+                        && isset($setIndents[$tokens[$condition]['scope_opener']]) === true
+                    ) {
+                        $checkIndent = $setIndents[$tokens[$condition]['scope_opener']];
+                        if (isset($adjustments[$condition]) === true) {
+                            $checkIndent += $adjustments[$condition];
                         }
 
-                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
-                        $prev  = $phpcsFile->findStartOfStatement($first);
-                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                        $currentIndent = $checkIndent;
+
+                        if ($this->_debug === true) {
+                            $type = $tokens[$condition]['type'];
+                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $condition ($type)".PHP_EOL;
+                        }
+                    } else {
+                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $parenOpener, true);
+
+                        $checkIndent = ($tokens[$first]['column'] - 1);
+                        if (isset($adjustments[$first]) === true) {
+                            $checkIndent += $adjustments[$first];
+                        }
+
                         if ($this->_debug === true) {
                             $line = $tokens[$first]['line'];
                             $type = $tokens[$first]['type'];
-                            echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
-                        }
-                    }
-
-                    if (isset($tokens[$first]['scope_closer']) === true
-                        && $tokens[$first]['scope_closer'] === $first
-                    ) {
-                        if ($this->_debug === true) {
-                            echo "\t* first token is a scope closer *".PHP_EOL;
+                            echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
                         }
 
-                        if (isset($tokens[$first]['scope_condition']) === true) {
-                            $scopeCloser = $first;
-                            $first       = $phpcsFile->findFirstOnLine(T_WHITESPACE, $tokens[$scopeCloser]['scope_condition'], true);
+                        if ($first === $tokens[$parenCloser]['parenthesis_opener']) {
+                            // This is unlikely to be the start of the statement, so look
+                            // back further to find it.
+                            $first--;
+                        }
 
+                        $prev = $phpcsFile->findStartOfStatement($first, T_COMMA);
+                        if ($prev !== $first) {
+                            // This is not the start of the statement.
+                            if ($this->_debug === true) {
+                                $line = $tokens[$prev]['line'];
+                                $type = $tokens[$prev]['type'];
+                                echo "\t* previous is $type on line $line *".PHP_EOL;
+                            }
+
+                            $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                            $prev  = $phpcsFile->findStartOfStatement($first, T_COMMA);
+                            $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                            if ($this->_debug === true) {
+                                $line = $tokens[$first]['line'];
+                                $type = $tokens[$first]['type'];
+                                echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
+                            }
+                        }
+
+                        if (isset($tokens[$first]['scope_closer']) === true
+                            && $tokens[$first]['scope_closer'] === $first
+                        ) {
+                            if ($this->_debug === true) {
+                                echo "\t* first token is a scope closer *".PHP_EOL;
+                            }
+
+                            if (isset($tokens[$first]['scope_condition']) === true) {
+                                $scopeCloser = $first;
+                                $first       = $phpcsFile->findFirstOnLine(T_WHITESPACE, $tokens[$scopeCloser]['scope_condition'], true);
+
+                                $currentIndent = ($tokens[$first]['column'] - 1);
+                                if (isset($adjustments[$first]) === true) {
+                                    $currentIndent += $adjustments[$first];
+                                }
+
+                                // Make sure it is divisible by our expected indent.
+                                if ($tokens[$tokens[$scopeCloser]['scope_condition']]['code'] !== T_CLOSURE) {
+                                    $currentIndent = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                                }
+
+                                $setIndents[$first] = $currentIndent;
+
+                                if ($this->_debug === true) {
+                                    $type = $tokens[$first]['type'];
+                                    echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                                }
+                            }//end if
+                        } else {
+                            // Don't force current indent to divisible because there could be custom
+                            // rules in place between parenthesis, such as with arrays.
                             $currentIndent = ($tokens[$first]['column'] - 1);
                             if (isset($adjustments[$first]) === true) {
                                 $currentIndent += $adjustments[$first];
-                            }
-
-                            // Make sure it is divisible by our expected indent.
-                            if ($tokens[$tokens[$scopeCloser]['scope_condition']]['code'] !== T_CLOSURE) {
-                                $currentIndent = (int) (ceil($currentIndent / $this->indent) * $this->indent);
                             }
 
                             $setIndents[$first] = $currentIndent;
 
                             if ($this->_debug === true) {
                                 $type = $tokens[$first]['type'];
-                                echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                                echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)".PHP_EOL;
                             }
                         }//end if
-                    } else {
-                        // Don't force current indent to divisible because there could be custom
-                        // rules in place between parenthesis, such as with arrays.
-                        $currentIndent = ($tokens[$first]['column'] - 1);
-                        if (isset($adjustments[$first]) === true) {
-                            $currentIndent += $adjustments[$first];
-                        }
-
-                        $setIndents[$first] = $currentIndent;
-
-                        if ($this->_debug === true) {
-                            $type = $tokens[$first]['type'];
-                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)".PHP_EOL;
-                        }
                     }//end if
                 } else if ($this->_debug === true) {
                     echo "\t * ignoring single-line definition *".PHP_EOL;
@@ -379,7 +438,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                         $first--;
                     }
 
-                    $prev = $phpcsFile->findStartOfStatement($first);
+                    $prev = $phpcsFile->findStartOfStatement($first, T_COMMA);
                     if ($prev !== $first) {
                         // This is not the start of the statement.
                         if ($this->_debug === true) {
@@ -389,7 +448,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                         }
 
                         $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
-                        $prev  = $phpcsFile->findStartOfStatement($first);
+                        $prev  = $phpcsFile->findStartOfStatement($first, T_COMMA);
                         $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
                         if ($this->_debug === true) {
                             $line = $tokens[$first]['line'];
@@ -929,13 +988,13 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 }
 
                 // Make sure it is divisible by our expected indent.
-                $currentIndent      = (int) (floor($currentIndent / $this->indent) * $this->indent);
-                $setIndents[$first] = $currentIndent;
+                $currentIndent = (int) (floor($currentIndent / $this->indent) * $this->indent);
                 $i = $tokens[$i]['scope_opener'];
+                $setIndents[$i] = $currentIndent;
 
                 if ($this->_debug === true) {
-                    $type = $tokens[$first]['type'];
-                    echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                    $type = $tokens[$i]['type'];
+                    echo "\t=> indent set to $currentIndent by token $i ($type)".PHP_EOL;
                 }
 
                 continue;
@@ -1152,7 +1211,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                     }
 
                     if ($condition === 0 || $tokens[$condition]['scope_opener'] < $first) {
-                        $currentIndent -= $this->indent;
+                        $currentIndent = $setIndents[$first];
                     } else if ($this->_debug === true) {
                         echo "\t* ignoring scope closer *".PHP_EOL;
                     }

--- a/pear/PHP/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -147,6 +147,12 @@ class PSR1_Sniffs_Files_SideEffectsSniff implements PHP_CodeSniffer_Sniff
                 continue;
             }
 
+            // Ignore anon classes.
+            if ($tokens[$i]['code'] === T_ANON_CLASS) {
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
             // Detect and skip over symbols.
             if (isset($symbols[$tokens[$i]['code']]) === true
                 && isset($tokens[$i]['scope_closer']) === true

--- a/pear/PHP/CodeSniffer/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -336,6 +336,7 @@ class PSR2_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_Clas
             } else if ($tokens[($className - 1)]['code'] !== T_NS_SEPARATOR
                 || $tokens[($className - 2)]['code'] !== T_STRING
             ) {
+                // Not part of a longer fully qualified class name.
                 if ($tokens[($className - 1)]['code'] === T_COMMA
                     || ($tokens[($className - 1)]['code'] === T_NS_SEPARATOR
                     && $tokens[($className - 2)]['code'] === T_COMMA)
@@ -369,7 +370,8 @@ class PSR2_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_Clas
                 }//end if
             }//end if
 
-            if ($tokens[($className + 1)]['code'] !== T_NS_SEPARATOR
+            if ($checkingImplements === true
+                && $tokens[($className + 1)]['code'] !== T_NS_SEPARATOR
                 && $tokens[($className + 1)]['code'] !== T_COMMA
             ) {
                 if ($i !== ($classCount - 1)) {

--- a/pear/PHP/CodeSniffer/Standards/PSR2/ruleset.xml
+++ b/pear/PHP/CodeSniffer/Standards/PSR2/ruleset.xml
@@ -161,6 +161,9 @@
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
  -->
+ <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpenBrace">
+  <severity>0</severity>
+ </rule>
  <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpaceBeforeCloseBrace">
   <severity>0</severity>
  </rule>

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -855,7 +855,7 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
 
                 if ($fix === true) {
                     // Find the end of the line and put a comma there.
-                    for ($i = ($index['value'] + 1); $i < $phpcsFile->numTokens; $i++) {
+                    for ($i = ($index['value'] + 1); $i < $arrayEnd; $i++) {
                         if ($tokens[$i]['line'] > $valueLine) {
                             break;
                         }

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -97,9 +97,14 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                     }
                 }
 
+                // Support both a return type and a description. The return type
+                // is anything up to the first space.
+                $returnParts = explode(' ', $content, 2);
+                $returnType  = $returnParts[0];
+
                 // If the return type is void, make sure there is
                 // no return statement in the function.
-                if ($content === 'void') {
+                if ($returnType === 'void') {
                     if (isset($tokens[$stackPtr]['scope_closer']) === true) {
                         $endToken = $tokens[$stackPtr]['scope_closer'];
                         for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++) {
@@ -125,7 +130,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                             }
                         }
                     }//end if
-                } else if ($content !== 'mixed') {
+                } else if ($returnType !== 'mixed') {
                     // If return type is not void, there needs to be a return statement
                     // somewhere in the function that returns something.
                     if (isset($tokens[$stackPtr]['scope_closer']) === true) {

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php
@@ -89,7 +89,7 @@ class Squiz_Sniffs_ControlStructures_InlineIfDeclarationSniff implements PHP_Cod
             return;
         }
 
-        $spaceBefore = ($tokens[$stackPtr]['column'] - ($tokens[$contentBefore]['column'] + strlen($tokens[$contentBefore]['content'])));
+        $spaceBefore = ($tokens[$stackPtr]['column'] - ($tokens[$contentBefore]['column'] + $tokens[$contentBefore]['length']));
         if ($spaceBefore !== 1) {
             $error = 'Inline shorthand IF statement requires 1 space before THEN; %s found';
             $data  = array($spaceBefore);
@@ -108,7 +108,7 @@ class Squiz_Sniffs_ControlStructures_InlineIfDeclarationSniff implements PHP_Cod
         $contentBefore = $phpcsFile->findPrevious(T_WHITESPACE, ($inlineElse - 1), null, true);
         $contentAfter  = $phpcsFile->findNext(T_WHITESPACE, ($inlineElse + 1), null, true);
 
-        $spaceBefore = ($tokens[$inlineElse]['column'] - ($tokens[$contentBefore]['column'] + strlen($tokens[$contentBefore]['content'])));
+        $spaceBefore = ($tokens[$inlineElse]['column'] - ($tokens[$contentBefore]['column'] + $tokens[$contentBefore]['length']));
         if ($spaceBefore !== 1) {
             $error = 'Inline shorthand IF statement requires 1 space before ELSE; %s found';
             $data  = array($spaceBefore);

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php
@@ -56,16 +56,26 @@ class Squiz_Sniffs_PHP_InnerFunctionsSniff implements PHP_CodeSniffer_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true) {
-            $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-            if ($tokens[$prev]['code'] === T_EQUAL) {
-                // Ignore closures.
-                return;
-            }
-
-            $error = 'The use of inner functions is forbidden';
-            $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+        $function = $phpcsFile->getCondition($stackPtr, T_FUNCTION);
+        if ($function === false) {
+            // Not a nested function.
+            return;
         }
+
+        $class = $phpcsFile->getCondition($stackPtr, T_ANON_CLASS);
+        if ($class !== false && $class > $function) {
+            // Ignore methods in anon classes.
+            return;
+        }
+
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$prev]['code'] === T_EQUAL) {
+            // Ignore closures.
+            return;
+        }
+
+        $error = 'The use of inner functions is forbidden';
+        $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
 
     }//end process()
 

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -66,7 +66,7 @@ class Squiz_Sniffs_PHP_NonExecutableCodeSniff implements PHP_CodeSniffer_Sniff
         // If this token is preceded with an "or", it only relates to one line
         // and should be ignored. For example: fopen() or die().
         $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($tokens[$prev]['code'] === T_LOGICAL_OR) {
+        if ($tokens[$prev]['code'] === T_LOGICAL_OR || $tokens[$prev]['code'] === T_BOOLEAN_OR) {
             return;
         }
 

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -63,6 +63,12 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
                     $fix   = $phpcsFile->addFixableError($error, $prev, 'AfterComment', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->beginChangeset();
+                        // Inline comments have the newline included in the content but
+                        // docblock do not.
+                        if ($tokens[$prev]['code'] === T_COMMENT) {
+                            $phpcsFile->fixer->replaceToken($prev, rtrim($tokens[$prev]['content']));
+                        }
+
                         for ($i = ($prev + 1); $i <= $stackPtr; $i++) {
                             if ($tokens[$i]['line'] === $tokens[$stackPtr]['line']) {
                                 break;

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -187,7 +187,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
             return;
         }//end if
 
-        if ($tokens[$stackPtr]['code'] === T_MINUS) {
+        if ($tokens[$stackPtr]['code'] === T_MINUS || $tokens[$stackPtr]['code'] === T_PLUS) {
             // Check minus spacing, but make sure we aren't just assigning
             // a minus value or returning one.
             $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);

--- a/pear/PHP/CodeSniffer/Tokens.php
+++ b/pear/PHP/CodeSniffer/Tokens.php
@@ -141,6 +141,10 @@ if (defined('T_SPACESHIP') === false) {
     define('T_SPACESHIP', 'PHPCS_T_SPACESHIP');
 }
 
+if (defined('T_COALESCE') === false) {
+    define('T_COALESCE', 'PHPCS_T_COALESCE');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');
@@ -215,6 +219,7 @@ final class PHP_CodeSniffer_Tokens
                                  T_MODULUS             => 5,
                                  T_POW                 => 5,
                                  T_SPACESHIP           => 5,
+                                 T_COALESCE            => 5,
 
                                  T_SL                  => 5,
                                  T_SR                  => 5,
@@ -375,6 +380,7 @@ final class PHP_CodeSniffer_Tokens
                                    T_MODULUS                  => 1,
                                    T_POW                      => 2,
                                    T_SPACESHIP                => 3,
+                                   T_COALESCE                 => 2,
                                    T_BITWISE_AND              => 1,
                                    T_BITWISE_OR               => 1,
                                    T_BITWISE_XOR              => 1,
@@ -566,6 +572,7 @@ final class PHP_CodeSniffer_Tokens
                                 T_MODULUS     => T_MODULUS,
                                 T_POW         => T_POW,
                                 T_SPACESHIP   => T_SPACESHIP,
+                                T_COALESCE    => T_COALESCE,
                                 T_BITWISE_AND => T_BITWISE_AND,
                                 T_BITWISE_OR  => T_BITWISE_OR,
                                 T_BITWISE_XOR => T_BITWISE_XOR,

--- a/pear/PHP/README.md
+++ b/pear/PHP/README.md
@@ -50,9 +50,9 @@ You will then be able to run PHP_CodeSniffer from the vendor bin directory:
     ./vendor/bin/phpcs -h
     ./vendor/bin/phpcbf -h
 
-You can also download the PHP\_CodeSniffer source and run the `phpcs` and `phpcbf` commands directly from the Git checkout:
+You can also download the PHP\_CodeSniffer source and run the `phpcs` and `phpcbf` commands directly from the Git clone:
 
-    git clone git://github.com/squizlabs/PHP_CodeSniffer.git
+    git clone https://github.com/squizlabs/PHP_CodeSniffer.git
     cd PHP_CodeSniffer
     php scripts/phpcs -h
     php scripts/phpcbf -h

--- a/readme_moodle.txt
+++ b/readme_moodle.txt
@@ -8,7 +8,7 @@ Instructions to upgrade the phpcs bundled version:
 
 Current checkout:
 
-  2.6.0 release(1bcdf03)
+  2.6.2 dev (2d3a4a8)
 
 Local modifications (only allowed if there is a PR upstream backing it):
 


### PR DESCRIPTION
Just upgraded to PHP_CodeSniffer 2.6.2 dev (2d3a4a8) and added some fixtures to ensure they are not reported as errors anymore.

Also, I've run it about various of the reported [cases in the tracker](https://tracker.moodle.org/browse/CONTRIB-6206) and, unless I'm missing something, all them seems fixed with the patch applied.