### PR TITLE
NOBUG: Adjust php combinations to, always, check older and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
+  - 5.6
   - 7.0
 
 env:
@@ -22,11 +22,32 @@ env:
 matrix:
   exclude:
     - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_27_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+      env: MOODLE_BRANCH=MOODLE_29_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
     - php: 7.0
       env: MOODLE_BRANCH=MOODLE_28_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
     - php: 7.0
+      env: MOODLE_BRANCH=MOODLE_27_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_31_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.6
       env: MOODLE_BRANCH=MOODLE_29_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_28_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_27_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+  include:
+    - php: 5.4
+      env: MOODLE_BRANCH=MOODLE_31_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.4
+      env: MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.4
+      env: MOODLE_BRANCH=MOODLE_29_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.4
+      env: MOODLE_BRANCH=MOODLE_28_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+    - php: 5.4
+      env: MOODLE_BRANCH=MOODLE_27_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
 
 before_install:
   - phpenv config-rm xdebug.ini


### PR DESCRIPTION
- PHP 3.2 and up get 5.6 and 7.0
- PHP 3.0 and 3.1 get 5.4 and 7.0
- PHP < 3.0 get php 5.4 only