### PR TITLE
Allow setUpBeforeClass as a valid function name

### DIFF
--- a/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -58,6 +58,7 @@ class moodle_Sniffs_NamingConventions_ValidFunctionNameSniff
     private $permittedmethods = array(
         'setUp',
         'tearDown', // Used by simpletest.
+        'setUpBeforeClass',
         'offsetExists',
         'offsetGet',
         'offsetSet',


### PR DESCRIPTION
This method is part of the PHPUnit API and it should not throw the
letter case error.

Discussed at https://github.com/moodlerooms/moodle-plugin-ci/issues/26