### PR TITLE
MDLSITE-3688 error if side effect detected

### DIFF
--- a/moodle/tests/fixtures/moodle_files_moodleinternal/warning.php
+++ b/moodle/tests/fixtures/moodle_files_moodleinternal/warning.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Chart line.
+ *
+ * @package    core
+ * @copyright  2016 Frédéric Massart - FMCorz.net
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Chart line class.
+ *
+ * @package    core
+ * @copyright  2016 Frédéric Massart - FMCorz.net
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class chart_line { }

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -446,9 +446,22 @@ class moodlestandard_testcase extends local_codechecker_testcase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors(array(
+            19 => 'Expected MOODLE_INTERNAL check or config.php inclusion'
+        ));
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_moodleinternal_warning() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_moodleinternal/warning.php');
+
         $this->set_errors(array());
         $this->set_warnings(array(
-            19 => 'Expected MOODLE_INTERNAL check or config.php inclusion'
+            32 => 'Expected MOODLE_INTERNAL check or config.php inclusion'
         ));
 
         $this->verify_cs_results();


### PR DESCRIPTION
Borrowed heavily from
https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php

We turn the warning into an error if side effect detected in the code.

Perhaps we should use different terminology in the errors/warnings? Thoughts welcome. Also needs some better testing
