### PR TITLE
MDLSITE-3688 login checks sniff

### DIFF
--- a/moodle/Sniffs/Files/RequireLoginSniff.php
+++ b/moodle/Sniffs/Files/RequireLoginSniff.php
@@ -1,0 +1,187 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Checks that each file contains necessary login checks.
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class moodle_Sniffs_Files_RequireLoginSniff implements PHP_CodeSniffer_Sniff {
+    public $loginfunctions = ['require_login', 'require_course_login', 'admin_externalpage_setup'];
+    public $ignorewhendefined = ['NO_MOODLE_COOKIES', 'CLI_SCRIPT', 'ABORT_AFTER_CONFIG'];
+    /**
+     * Register for open tag (only process once per file).
+     */
+    public function register() {
+        return array(T_OPEN_TAG);
+    }
+
+    /**
+     * Processes php files and for required login checks if includeing config.php
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     */
+    public function process(PHP_CodeSniffer_File $file, $pointer) {
+        // We only want to do this once per file.
+        $prevopentag = $file->findPrevious(T_OPEN_TAG, $pointer - 1);
+        if ($prevopentag !== false) {
+            return;
+        }
+
+        $pointer = $this->get_config_inclusion_position($file, $pointer);
+        if ($pointer === false) {
+            // Config.php not included form file.
+            return;
+        }
+
+        // OK, we've got a config.php.
+        if ($this->should_skip_login_checks($file, $pointer)) {
+            // Login function check not necessary.
+            return;
+        }
+
+        if (!$this->is_login_function_present($file, $pointer)) {
+            $loginfunctionsstr = implode(', ', $this->loginfunctions);
+            $file->addWarning("Expected login check ($loginfunctionsstr) following config inclusion. None found.", $pointer);
+        }
+    }
+
+    /**
+     * Returns the position of a config.php require statement in the stack.
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     * @return int|false the position in the file or false if no require statement found.
+     */
+    protected function get_config_inclusion_position(PHP_CodeSniffer_File $file, $pointer) {
+        for ($i = $pointer; $i < $file->numTokens; $i++) {
+            $i = $file->findNext([T_REQUIRE, T_REQUIRE_ONCE], $i);
+            if ($i === false) {
+                // No require statement in file.
+                return false;
+            }
+
+            if ($this->is_a_config_php_incluson($file, $i)) {
+                // Found config.php.
+                return $i;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Is the current position a config.php inclusion?
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     * @return bool true if it is a config inclusion
+     */
+    protected function is_a_config_php_incluson(PHP_CodeSniffer_File $file, $pointer) {
+        $tokens = $file->getTokens();
+
+        // It's a require() or require_once() statement. Is it require(config.php)?
+        $requirecontent = $file->getTokensAsString($pointer, ($file->findEndOfStatement($pointer) - $pointer));
+        if (strpos($requirecontent, '/config.php') === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Should we skip the login checks? We look back up the stack to see if there are any
+     * define statements which cause us to skip the checks (e.g. CLI_SCRIPT)
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     * @return bool true if the checks should be skipped
+     */
+    protected function should_skip_login_checks(PHP_CodeSniffer_File $file, $pointer) {
+        $tokens = $file->getTokens();
+
+        for ($i = $pointer; $i > 0; $i--) {
+
+            $i = $file->findPrevious(T_STRING, $i);
+            if ($i === false) {
+                // We've got to the start. A login function must be necessary.
+                return false;
+            }
+
+            if (strtolower($tokens[$i]['content']) !== 'define') {
+                // Not a define statement, let move onto the next string.
+                continue;
+            }
+
+            // TODO, do this the non-lazy more strict way?
+            $definecontent = $file->getTokensAsString($i, ($file->findEndOfStatement($i) - $i));
+            foreach ($this->ignorewhendefined as $name) {
+                if (strpos($definecontent, $name) !== false) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is the current position a login function?
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     * @return bool true if the current point in stack is a login function.
+     */
+    protected function is_a_login_function(PHP_CodeSniffer_File $file, $pointer) {
+        $tokens = $file->getTokens();
+
+        if (in_array($tokens[$pointer]['content'], $this->loginfunctions)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Is there a login function present in the following code?
+     *
+     * @param PHP_CodeSniffer_File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     * @return true if login function is present.
+     */
+    protected function is_login_function_present(PHP_CodeSniffer_File $file, $pointer) {
+        for ($i = $pointer; $i < $file->numTokens; $i++) {
+            $i = $file->findNext(T_STRING, $i);
+            if ($i === false) {
+                return false;
+            }
+
+            if ($this->is_a_login_function($file, $i)) {
+                return true;
+            }
+
+            // FIXME: jumping to next semi colon to reduce the tokens checked. Perhaps a better way?
+            $i = $file->findNext(T_SEMICOLON, $i);
+            if ($i === false) {
+                return false;
+            }
+        }
+
+    }
+}

--- a/moodle/tests/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+$id = required_param('id', PARAM_INT);
+
+admin_externalpage_setup('testpage');
+
+echo "Do something with $id";

--- a/moodle/tests/fixtures/moodle_files_requirelogin/cliscript_ok.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/cliscript_ok.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+require_once(__DIR__ . '/../../../config.php');
+
+echo "Do something with on cli.";

--- a/moodle/tests/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('NO_MOODLE_COOKIES', true);
+require_once(__DIR__ . '/../../../config.php');
+
+$id = required_param('id', PARAM_INT);
+
+echo "Do something with $id";

--- a/moodle/tests/fixtures/moodle_files_requirelogin/problem.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/problem.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+$id = required_param('id', PARAM_INT);
+
+echo "Do something with $id";

--- a/moodle/tests/fixtures/moodle_files_requirelogin/require_course_login_ok.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/require_course_login_ok.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+$id = required_param('id', PARAM_INT);
+$course = get_course($id);
+
+require_course_login($course);
+
+echo "Do something with $course->name";

--- a/moodle/tests/fixtures/moodle_files_requirelogin/require_login_ok.php
+++ b/moodle/tests/fixtures/moodle_files_requirelogin/require_login_ok.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Fixture for require login sniff
+ *
+ * @package    local_codechecker
+ * @copyright  2016 Dan Poltawski <dan@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+require_login(null, false);
+$id = required_param('id', PARAM_INT);
+
+echo "Do something with $id";

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -523,4 +523,72 @@ class moodlestandard_testcase extends local_codechecker_testcase {
 
         $this->verify_cs_results();
     }
+
+    public function test_moodle_files_requirelogin_problem() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/problem.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array(
+            25 => 'Expected login check (require_login, require_course_login, admin_externalpage_setup) following config inclusion. None found'
+        ));
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_requirelogin_require_login_ok() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_login_ok.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_requirelogin_require_course_login_ok() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_course_login_ok.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_requirelogin_admin_externalpage_setup_ok() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_requirelogin_cliscript_ok() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/cliscript_ok.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_requirelogin_nomoodlecookies_ok() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.RequireLogin');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        $this->verify_cs_results();
+    }
 }


### PR DESCRIPTION
Sniff to detect files without required login functions, based on the ideas from @FMCorz in [MDLSITE-3688](https://tracker.moodle.org/browse/MDLSITE-3688).

I am torn about this idea - I am not sure if we can do this sniff reliably and thats probably the most important blocker. I'm especially worried about the use case of a module which makes its own wrapper function doing these kind of checks. This would seem noisy - we have an example of that in useredit_setup_preference_page().

On the other hand, I think this could potentially find real important issues in files. So maybe it would be useful as a warning. Interested in your thoughts @mudrd8mz and @mrmark.

Current matches in core isn't too bad
https://gist.github.com/danpoltawski/edc6b9ae1b6ccb62482be93a3c2052b7
