### PR TITLE
NOBUG: Bump to PHP_CodeSniffer 2.7.0 (571e27b)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Changes in version 2.7.0 (YYYYMMDD) - Boosting you!
+---------------------------------------------------
+- NOBUG: Updated PHP_CodeSniffer to 2.7.0 version.
+
 Changes in version 2.5.4 (20160930) - Internally safe
 -----------------------------------------------------
 - NOBUG: Updated PHP_CodeSniffer to 2.6.2 version.

--- a/pear/PHP/CONTRIBUTING.md
+++ b/pear/PHP/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing
 Before you contribute code to PHP\_CodeSniffer, please make sure it conforms to the PHPCS coding standard and that the PHP\_CodeSniffer unit tests still pass. The easiest way to contribute is to work on a checkout of the repository, or your own fork, rather than an installed PEAR version. If you do this, you can run the following commands to check if everything is ready to submit:
 
     cd PHP_CodeSniffer
-    php scripts/phpcs . --standard=PHPCS -np
+    php scripts/phpcs
 
 Which should give you no output, indicating that there are no coding standard errors. And then:
 

--- a/pear/PHP/CodeSniffer.php
+++ b/pear/PHP/CodeSniffer.php
@@ -73,7 +73,7 @@ class PHP_CodeSniffer
      *
      * @var string
      */
-    const VERSION = '2.6.2';
+    const VERSION = '2.7.0';
 
     /**
      * Package stability; either stable, beta or alpha.
@@ -548,7 +548,7 @@ class PHP_CodeSniffer
             }
 
             if (PHP_CODESNIFFER_VERBOSITY === 1) {
-                $ruleset = simplexml_load_file($standard);
+                $ruleset = simplexml_load_string(file_get_contents($standard));
                 if ($ruleset !== false) {
                     $standardName = (string) $ruleset['name'];
                 }
@@ -711,7 +711,7 @@ class PHP_CodeSniffer
             echo "Processing ruleset $rulesetPath".PHP_EOL;
         }
 
-        $ruleset = simplexml_load_file($rulesetPath);
+        $ruleset = simplexml_load_string(file_get_contents($rulesetPath));
         if ($ruleset === false) {
             throw new PHP_CodeSniffer_Exception("Ruleset $rulesetPath is not valid");
         }
@@ -2093,13 +2093,17 @@ class PHP_CodeSniffer
             $lowerVarType = strtolower($varType);
             switch ($lowerVarType) {
             case 'bool':
+            case 'boolean':
                 return 'boolean';
             case 'double':
             case 'real':
+            case 'float':
                 return 'float';
             case 'int':
+            case 'integer':
                 return 'integer';
             case 'array()':
+            case 'array':
                 return 'array';
             }//end switch
 

--- a/pear/PHP/CodeSniffer/Standards/Generic/Docs/Classes/OpeningBraceSameLineStandard.xml
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Docs/Classes/OpeningBraceSameLineStandard.xml
@@ -1,0 +1,28 @@
+<documentation title="Opening Brace on Same Line">
+    <standard>
+    <![CDATA[
+    The opening brace of a class must be on the same line after the definition and must be the last thing on that line.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Opening brace on the same line.">
+        <![CDATA[
+class Foo <em>{</em>
+}
+        ]]>
+        </code>
+        <code title="Invalid: Opening brace on the next line.">
+        <![CDATA[
+class Foo
+<em>{</em>
+}
+        ]]>
+        </code>
+        <code title="Invalid: Opening brace not last thing on the line.">
+        <![CDATA[
+class Foo {<em> // Start of class.</em>
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/pear/PHP/CodeSniffer/Standards/Generic/Docs/PHP/BacktickOperatorStandard.xml
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Docs/PHP/BacktickOperatorStandard.xml
@@ -1,0 +1,7 @@
+<documentation title="Backtick Operator">
+    <standard>
+    <![CDATA[
+    Disallow the use of the backtick operator for execution of shell commands.
+    ]]>
+    </standard>
+</documentation>

--- a/pear/PHP/CodeSniffer/Standards/Generic/Docs/PHP/DisallowAlternativePHPTagsStandard.xml
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Docs/PHP/DisallowAlternativePHPTagsStandard.xml
@@ -1,0 +1,7 @@
+<documentation title="Alternative PHP Code Tags">
+    <standard>
+    <![CDATA[
+    Always use <?php ?> to delimit PHP code, do not use the ASP <% %> style tags nor the <script language="php"></script> tags. This is the most portable way to include PHP code on differing operating systems and setups.
+    ]]>
+    </standard>
+</documentation>

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Generic_Sniffs_Classes_OpeningBraceSameLineSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_Classes_OpeningBraceSameLineSniff.
+ *
+ * Checks that the opening brace of a class or interface is on the same line
+ * as the class declaration.
+ *
+ * Also checks that the brace is the last thing on that line and has precisely one space before it.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Classes_OpeningBraceSameLineSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_CLASS,
+                T_INTERFACE,
+                T_TRAIT,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens           = $phpcsFile->getTokens();
+        $scope_identifier = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        $errorData        = array(strtolower($tokens[$stackPtr]['content']).' '.$tokens[$scope_identifier]['content']);
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            $error = 'Possible parse error: %s missing opening or closing brace';
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+            return;
+        }
+
+        $openingBrace = $tokens[$stackPtr]['scope_opener'];
+
+        // Is the brace on the same line as the class/interface/trait declaration ?
+        $lastClassLineToken = $phpcsFile->findPrevious(T_STRING, ($openingBrace - 1), $stackPtr);
+        $lastClassLine      = $tokens[$lastClassLineToken]['line'];
+        $braceLine          = $tokens[$openingBrace]['line'];
+        $lineDifference     = ($braceLine - $lastClassLine);
+
+        if ($lineDifference > 0) {
+            $phpcsFile->recordMetric($stackPtr, 'Class opening brace placement', 'new line');
+            $error = 'Opening brace should be on the same line as the declaration for %s';
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'BraceOnNewLine', $errorData);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addContent($lastClassLineToken, ' {');
+                $phpcsFile->fixer->replaceToken($openingBrace, '');
+                $phpcsFile->fixer->endChangeset();
+            }
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Class opening brace placement', 'same line');
+        }
+
+        // Is the opening brace the last thing on the line ?
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($openingBrace + 1), null, true);
+        if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {
+            if ($next === $tokens[$stackPtr]['scope_closer']) {
+                // Ignore empty classes.
+                return;
+            }
+
+            $error = 'Opening brace must be the last content on the line';
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
+            if ($fix === true) {
+                $phpcsFile->fixer->addNewline($openingBrace);
+            }
+        }
+
+        // Only continue checking if the opening brace looks good.
+        if ($lineDifference > 0) {
+            return;
+        }
+
+        // Is there precisely one space before the opening brace ?
+        if ($tokens[($openingBrace - 1)]['code'] !== T_WHITESPACE) {
+            $length = 0;
+        } else if ($tokens[($openingBrace - 1)]['content'] === "\t") {
+            $length = '\t';
+        } else {
+            $length = strlen($tokens[($openingBrace - 1)]['content']);
+        }
+
+        if ($length !== 1) {
+            $error = 'Expected 1 space before opening brace; found %s';
+            $data  = array($length);
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'SpaceBeforeBrace', $data);
+            if ($fix === true) {
+                if ($length === 0 || $length === '\t') {
+                    $phpcsFile->fixer->addContentBefore($openingBrace, ' ');
+                } else {
+                    $phpcsFile->fixer->replaceToken(($openingBrace - 1), ' ');
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -202,13 +202,27 @@ class Generic_Sniffs_ControlStructures_InlineControlStructureSniff implements PH
                     }
                 }//end if
 
-                break;
+                if ($tokens[$end]['code'] !== T_END_HEREDOC
+                    && $tokens[$end]['code'] !== T_END_NOWDOC
+                ) {
+                    break;
+                }
             }//end if
+
+            if (isset($tokens[$end]['parenthesis_closer']) === true) {
+                $end          = $tokens[$end]['parenthesis_closer'];
+                $lastNonEmpty = $end;
+                continue;
+            }
 
             if ($tokens[$end]['code'] !== T_WHITESPACE) {
                 $lastNonEmpty = $end;
             }
         }//end for
+
+        if ($end === $phpcsFile->numTokens) {
+            $end = $lastNonEmpty;
+        }
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($closer + 1), ($end + 1), true);
 
@@ -227,16 +241,50 @@ class Generic_Sniffs_ControlStructures_InlineControlStructureSniff implements PH
 
         if ($next !== $end) {
             if ($endLine !== $end) {
-                $phpcsFile->fixer->addContent($endLine, '}');
+                $endToken     = $endLine;
+                $addedContent = '';
             } else {
+                $endToken     = $end;
+                $addedContent = $phpcsFile->eolChar;
+
                 if ($tokens[$end]['code'] !== T_SEMICOLON
                     && $tokens[$end]['code'] !== T_CLOSE_CURLY_BRACKET
                 ) {
-                    $phpcsFile->fixer->addContent($end, ';');
+                    $phpcsFile->fixer->addContent($end, '; ');
+                }
+            }
+
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($endToken + 1), null, true);
+            if ($next !== false
+                && ($tokens[$next]['code'] === T_ELSE
+                || $tokens[$next]['code'] === T_ELSEIF)
+            ) {
+                $phpcsFile->fixer->addContentBefore($next, '} ');
+            } else {
+                $indent = '';
+                for ($first = $stackPtr; $first > 0; $first--) {
+                    if ($first === 1
+                        || $tokens[($first - 1)]['line'] !== $tokens[$first]['line']
+                    ) {
+                        break;
+                    }
                 }
 
-                $phpcsFile->fixer->addContent($end, ' }');
-            }
+                if ($tokens[$first]['code'] === T_WHITESPACE) {
+                    $indent = $tokens[$first]['content'];
+                } else if ($tokens[$first]['code'] === T_INLINE_HTML
+                    || $tokens[$first]['code'] === T_OPEN_TAG
+                ) {
+                    $addedContent = '';
+                }
+
+                $addedContent .= $indent.'}';
+                if ($next !== false && $tokens[$endToken]['code'] === T_COMMENT) {
+                    $addedContent .= $phpcsFile->eolChar;
+                }
+
+                $phpcsFile->fixer->addContent($endToken, $addedContent);
+            }//end if
         } else {
             if ($endLine !== $end) {
                 $phpcsFile->fixer->replaceToken($end, '');

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -129,7 +129,13 @@ class Generic_Sniffs_Files_LineEndingsSniff implements PHP_CodeSniffer_Sniff
                     || $tokens[($i + 1)]['line'] > $tokens[$i]['line']
                 ) {
                     // Token is the last on a line.
-                    $newContent  = rtrim($tokens[$i]['content'], "\r\n");
+                    if (isset($tokens[$i]['orig_content']) === true) {
+                        $tokenContent = $tokens[$i]['orig_content'];
+                    } else {
+                        $tokenContent = $tokens[$i]['content'];
+                    }
+
+                    $newContent  = rtrim($tokenContent, "\r\n");
                     $newContent .= $eolChar;
                     $phpcsFile->fixer->replaceToken($i, $newContent);
                 }

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -111,9 +111,26 @@ class Generic_Sniffs_Functions_OpeningFunctionBraceKernighanRitchieSniff impleme
                 $phpcsFile->fixer->beginChangeset();
                 $phpcsFile->fixer->addContent($prev, ' {');
                 $phpcsFile->fixer->replaceToken($openingBrace, '');
+                if ($tokens[($openingBrace + 1)]['code'] === T_WHITESPACE
+                    && $tokens[($openingBrace + 2)]['line'] > $tokens[$openingBrace]['line']
+                ) {
+                    // Brace is followed by a new line, so remove it to ensure we don't
+                    // leave behind a blank line at the top of the block.
+                    $phpcsFile->fixer->replaceToken(($openingBrace + 1), '');
+
+                    if ($tokens[($openingBrace - 1)]['code'] === T_WHITESPACE
+                        && $tokens[($openingBrace - 1)]['line'] === $tokens[$openingBrace]['line']
+                        && $tokens[($openingBrace - 2)]['line'] < $tokens[$openingBrace]['line']
+                    ) {
+                        // Brace is preceeded by indent, so remove it to ensure we don't
+                        // leave behind more indent than is required for the first line.
+                        $phpcsFile->fixer->replaceToken(($openingBrace - 1), '');
+                    }
+                }
+
                 $phpcsFile->fixer->endChangeset();
-            }
-        }
+            }//end if
+        }//end if
 
         $phpcsFile->recordMetric($stackPtr, 'Function opening brace placement', 'same line');
 
@@ -136,23 +153,23 @@ class Generic_Sniffs_Functions_OpeningFunctionBraceKernighanRitchieSniff impleme
             return;
         }
 
-        if ($tokens[($closeBracket + 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[($openingBrace - 1)]['code'] !== T_WHITESPACE) {
             $length = 0;
-        } else if ($tokens[($closeBracket + 1)]['content'] === "\t") {
+        } else if ($tokens[($openingBrace - 1)]['content'] === "\t") {
             $length = '\t';
         } else {
-            $length = strlen($tokens[($closeBracket + 1)]['content']);
+            $length = strlen($tokens[($openingBrace - 1)]['content']);
         }
 
         if ($length !== 1) {
-            $error = 'Expected 1 space after closing parenthesis; found %s';
+            $error = 'Expected 1 space before opening brace; found %s';
             $data  = array($length);
-            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'SpaceAfterBracket', $data);
+            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'SpaceBeforeBrace', $data);
             if ($fix === true) {
                 if ($length === 0 || $length === '\t') {
-                    $phpcsFile->fixer->addContent($closeBracket, ' ');
+                    $phpcsFile->fixer->addContentBefore($openingBrace, ' ');
                 } else {
-                    $phpcsFile->fixer->replaceToken(($closeBracket + 1), ' ');
+                    $phpcsFile->fixer->replaceToken(($openingBrace - 1), ' ');
                 }
             }
         }

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -157,6 +157,13 @@ class Generic_Sniffs_NamingConventions_UpperCaseConstantNameSniff implements PHP
             $constName = substr($constName, ($splitPos + 2));
         }
 
+        // Strip namesspace from constant like /foo/bar/CONSTANT.
+        $splitPos = strrpos($constName, '\\');
+        if ($splitPos !== false) {
+            $prefix    = substr($constName, 0, ($splitPos + 1));
+            $constName = substr($constName, ($splitPos + 1));
+        }
+
         if (strtoupper($constName) !== $constName) {
             if (strtolower($constName) === $constName) {
                 $phpcsFile->recordMetric($stackPtr, 'Constant name case', 'lower');

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Generic_Sniffs_PHP_BacktickOperatorSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_PHP_BacktickOperatorSniff.
+ *
+ * Checks for the use of the backtick execution operator.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_PHP_BacktickOperatorSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_BACKTICK);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $error = 'Use of the backtick operator is forbidden';
+        $phpcsFile->addError($error, $stackPtr, 'Found');
+
+    }//end process()
+
+
+}//end class

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff.
+ *
+ * Verifies that no alternative PHP tags are used.
+ *
+ * If alternative PHP open tags are found, this sniff can fix both the open and close tags.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Whether ASP tags are enabled or not.
+     *
+     * @var bool
+     */
+    private $_aspTags = false;
+
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
+        }
+
+        if ($this->_phpVersion < 70000) {
+            $this->_aspTags = (boolean) ini_get('asp_tags');
+        }
+
+        return array(
+                T_OPEN_TAG,
+                T_OPEN_TAG_WITH_ECHO,
+                T_INLINE_HTML,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens  = $phpcsFile->getTokens();
+        $openTag = $tokens[$stackPtr];
+        $content = $openTag['content'];
+
+        if (trim($content) === '') {
+            return;
+        }
+
+        if ($openTag['code'] === T_OPEN_TAG) {
+            if ($content === '<%') {
+                $error     = 'ASP style opening tag used; expected "<?php" but found "%s"';
+                $closer    = $this->findClosingTag($phpcsFile, $tokens, $stackPtr, '%>');
+                $errorCode = 'ASPOpenTagFound';
+            } else if (strpos($content, '<script ') !== false) {
+                $error     = 'Script style opening tag used; expected "<?php" but found "%s"';
+                $closer    = $this->findClosingTag($phpcsFile, $tokens, $stackPtr, '</script>');
+                $errorCode = 'ScriptOpenTagFound';
+            }
+
+            if (isset($error, $closer, $errorCode) === true) {
+                $data = array($content);
+
+                if ($closer === false) {
+                    $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+                } else {
+                    $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+                    if ($fix === true) {
+                        $this->addChangeset($phpcsFile, $tokens, $stackPtr, $closer);
+                    }
+                }
+            }
+
+            return;
+        }//end if
+
+        if ($openTag['code'] === T_OPEN_TAG_WITH_ECHO && $content === '<%=') {
+            $error   = 'ASP style opening tag used with echo; expected "<?php echo %s ..." but found "%s %s ..."';
+            $nextVar = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            $snippet = $this->getSnippet($tokens[$nextVar]['content']);
+            $data    = array(
+                        $snippet,
+                        $content,
+                        $snippet,
+                       );
+
+            $closer = $this->findClosingTag($phpcsFile, $tokens, $stackPtr, '%>');
+
+            if ($closer === false) {
+                $phpcsFile->addError($error, $stackPtr, 'ASPShortOpenTagFound', $data);
+            } else {
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ASPShortOpenTagFound', $data);
+                if ($fix === true) {
+                    $this->addChangeset($phpcsFile, $tokens, $stackPtr, $closer, true);
+                }
+            }
+
+            return;
+        }//end if
+
+        // Account for incorrect script open tags.
+        // The "(?:<s)?" in the regex is to work-around a bug in PHP 5.2.
+        if ($openTag['code'] === T_INLINE_HTML
+            && preg_match('`((?:<s)?cript (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
+        ) {
+            $error   = 'Script style opening tag used; expected "<?php" but found "%s"';
+            $snippet = $this->getSnippet($content, $match[1]);
+            $data    = array($match[1].$snippet);
+
+            $phpcsFile->addError($error, $stackPtr, 'ScriptOpenTagFound', $data);
+            return;
+        }
+
+        if ($openTag['code'] === T_INLINE_HTML && $this->_aspTags === false) {
+            if (strpos($content, '<%=') !== false) {
+                $error   = 'Possible use of ASP style short opening tags detected. Needs manual inspection. Found: %s';
+                $snippet = $this->getSnippet($content, '<%=');
+                $data    = array('<%='.$snippet);
+
+                $phpcsFile->addWarning($error, $stackPtr, 'MaybeASPShortOpenTagFound', $data);
+            } else if (strpos($content, '<%') !== false) {
+                $error   = 'Possible use of ASP style opening tags detected. Needs manual inspection. Found: %s';
+                $snippet = $this->getSnippet($content, '<%');
+                $data    = array('<%'.$snippet);
+
+                $phpcsFile->addWarning($error, $stackPtr, 'MaybeASPOpenTagFound', $data);
+            }
+        }
+
+    }//end process()
+
+
+    /**
+     * Get a snippet from a HTML token.
+     *
+     * @param string $content  The content of the HTML token.
+     * @param string $start_at Partial string to use as a starting point for the snippet.
+     * @param int    $length   The target length of the snippet to get. Defaults to 40.
+     *
+     * @return string
+     */
+    protected function getSnippet($content, $start_at = '', $length = 40)
+    {
+        $start_pos = 0;
+
+        if ($start_at !== '') {
+            $start_pos = strpos($content, $start_at);
+            if ($start_pos !== false) {
+                $start_pos += strlen($start_at);
+            }
+        }
+
+        $snippet = substr($content, $start_pos, $length);
+        if ((strlen($content) - $start_pos) > $length) {
+            $snippet .= '...';
+        }
+
+        return $snippet;
+
+    }//end getSnippet()
+
+
+    /**
+     * Try and find a matching PHP closing tag.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param array                $tokens    The token stack.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     * @param string               $content   The expected content of the closing tag to match the opener.
+     *
+     * @return int|false Pointer to the position in the stack for the closing tag or false if not found.
+     */
+    protected function findClosingTag(PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr, $content)
+    {
+        $closer = $phpcsFile->findNext(T_CLOSE_TAG, ($stackPtr + 1));
+
+        if ($closer !== false && $content === trim($tokens[$closer]['content'])) {
+            return $closer;
+        }
+
+        return false;
+
+    }//end findClosingTag()
+
+
+    /**
+     * Add a changeset to replace the alternative PHP tags.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile         The file being scanned.
+     * @param array                $tokens            The token stack.
+     * @param int                  $open_tag_pointer  Stack pointer to the PHP open tag.
+     * @param int                  $close_tag_pointer Stack pointer to the PHP close tag.
+     * @param bool                 $echo              Whether to add 'echo' or not.
+     *
+     * @return void
+     */
+    protected function addChangeset(PHP_CodeSniffer_File $phpcsFile, $tokens, $open_tag_pointer, $close_tag_pointer, $echo = false)
+    {
+        // Build up the open tag replacement and make sure there's always whitespace behind it.
+        $open_replacement = '<?php';
+        if ($echo === true) {
+            $open_replacement .= ' echo';
+        }
+
+        if ($tokens[($open_tag_pointer + 1)]['code'] !== T_WHITESPACE) {
+            $open_replacement .= ' ';
+        }
+
+        // Make sure we don't remove any line breaks after the closing tag.
+        $regex = '`'.preg_quote(trim($tokens[$close_tag_pointer]['content'])).'`';
+        $close_replacement = preg_replace($regex, '?>', $tokens[$close_tag_pointer]['content']);
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->replaceToken($open_tag_pointer, $open_replacement);
+        $phpcsFile->fixer->replaceToken($close_tag_pointer, $close_replacement);
+        $phpcsFile->fixer->endChangeset();
+
+    }//end addChangeset()
+
+
+}//end class

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -63,7 +63,11 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
         if ($openTag['content'] === '<?') {
             $error = 'Short PHP opening tag used; expected "<?php" but found "%s"';
             $data  = array($openTag['content']);
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, '<?php');
+            }
+
             $phpcsFile->recordMetric($stackPtr, 'PHP short open tag used', 'yes');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PHP short open tag used', 'no');
@@ -77,7 +81,14 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
                         $openTag['content'],
                         $nextVar['content'],
                        );
-            $phpcsFile->addError($error, $stackPtr, 'EchoFound', $data);
+            $fix     = $phpcsFile->addFixableError($error, $stackPtr, 'EchoFound', $data);
+            if ($fix === true) {
+                if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo ');
+                } else {
+                    $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo');
+                }
+            }
         }
 
     }//end process()

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -102,6 +102,9 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
             }
         }
 
+        $this->forbiddenFunctionNames = array_map('strtolower', $this->forbiddenFunctionNames);
+        $this->forbiddenFunctions     = array_combine($this->forbiddenFunctionNames, $this->forbiddenFunctions);
+
         return array_unique($register);
 
     }//end register()
@@ -188,7 +191,7 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
             }
         }//end if
 
-        $this->addError($phpcsFile, $stackPtr, $function, $pattern);
+        $this->addError($phpcsFile, $stackPtr, $tokens[$stackPtr]['content'], $pattern);
 
     }//end process()
 
@@ -217,7 +220,7 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
         }
 
         if ($pattern === null) {
-            $pattern = $function;
+            $pattern = strtolower($function);
         }
 
         if ($this->forbiddenFunctions[$pattern] !== null

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -30,6 +30,13 @@
 class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * The path to the PHP version we are checking with.
+     *
+     * @var string
+     */
+    private $_phpPath = null;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -54,18 +61,20 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $phpPath = PHP_CodeSniffer::getConfigData('php_path');
-        if ($phpPath === null) {
-            // PHP_BINARY is available in PHP 5.4+.
-            if (defined('PHP_BINARY') === true) {
-                $phpPath = PHP_BINARY;
-            } else {
-                return;
+        if ($this->_phpPath === null) {
+            $this->_phpPath = PHP_CodeSniffer::getConfigData('php_path');
+            if ($this->_phpPath === null) {
+                // PHP_BINARY is available in PHP 5.4+.
+                if (defined('PHP_BINARY') === true) {
+                    $this->_phpPath = PHP_BINARY;
+                } else {
+                    return;
+                }
             }
         }
 
         $fileName = $phpcsFile->getFilename();
-        $cmd      = "$phpPath -l \"$fileName\" 2>&1";
+        $cmd      = $this->_phpPath." -l \"$fileName\" 2>&1";
         $output   = shell_exec($cmd);
 
         $matches = array();

--- a/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -296,7 +296,23 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
 
                     $exact = false;
 
-                    if ($condition > 0
+                    if ($condition > 0 && $lastOpenTag > $condition) {
+                        if ($this->_debug === true) {
+                            echo "\t* open tag is inside condition; using open tag *".PHP_EOL;
+                        }
+
+                        $checkIndent = ($tokens[$lastOpenTag]['column'] - 1);
+                        if (isset($adjustments[$condition]) === true) {
+                            $checkIndent += $adjustments[$condition];
+                        }
+
+                        $currentIndent = $checkIndent;
+
+                        if ($this->_debug === true) {
+                            $type = $tokens[$lastOpenTag]['type'];
+                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $lastOpenTag ($type)".PHP_EOL;
+                        }
+                    } else if ($condition > 0
                         && isset($tokens[$condition]['scope_opener']) === true
                         && isset($setIndents[$tokens[$condition]['scope_opener']]) === true
                     ) {
@@ -962,13 +978,14 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 continue;
             }//end if
 
-            // Closures set the indent based on their own indent level.
-            if ($tokens[$i]['code'] === T_CLOSURE) {
+            // Anon classes and functions set the indent based on their own indent level.
+            if ($tokens[$i]['code'] === T_CLOSURE || $tokens[$i]['code'] === T_ANON_CLASS) {
                 $closer = $tokens[$i]['scope_closer'];
                 if ($tokens[$i]['line'] === $tokens[$closer]['line']) {
                     if ($this->_debug === true) {
+                        $type = str_replace('_', ' ', strtolower(substr($tokens[$i]['type'], 2)));
                         $line = $tokens[$i]['line'];
-                        echo "* ignoring single-line closure on line $line".PHP_EOL;
+                        echo "* ignoring single-line $type on line $line".PHP_EOL;
                     }
 
                     $i = $closer;
@@ -976,8 +993,9 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 }
 
                 if ($this->_debug === true) {
+                    $type = str_replace('_', ' ', strtolower(substr($tokens[$i]['type'], 2)));
                     $line = $tokens[$i]['line'];
-                    echo "Open closure on line $line".PHP_EOL;
+                    echo "Open $type on line $line".PHP_EOL;
                 }
 
                 $first         = $phpcsFile->findFirstOnLine(T_WHITESPACE, $i, true);
@@ -1078,14 +1096,16 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 continue;
             }//end if
 
-            // Closing a closure.
+            // Closing an anon class or function.
             if (isset($tokens[$i]['scope_condition']) === true
                 && $tokens[$i]['scope_closer'] === $i
-                && $tokens[$tokens[$i]['scope_condition']]['code'] === T_CLOSURE
+                && ($tokens[$tokens[$i]['scope_condition']]['code'] === T_CLOSURE
+                || $tokens[$tokens[$i]['scope_condition']]['code'] === T_ANON_CLASS)
             ) {
                 if ($this->_debug === true) {
+                    $type = str_replace('_', ' ', strtolower(substr($tokens[$tokens[$i]['scope_condition']]['type'], 2)));
                     $line = $tokens[$i]['line'];
-                    echo "Close closure on line $line".PHP_EOL;
+                    echo "Close $type on line $line".PHP_EOL;
                 }
 
                 $prev = false;

--- a/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -172,10 +172,6 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
                    T_ABSTRACT,
                    T_CONST,
                    T_PROPERTY,
-                   T_INCLUDE,
-                   T_INCLUDE_ONCE,
-                   T_REQUIRE,
-                   T_REQUIRE_ONCE,
                   );
 
         if (in_array($tokens[$nextToken]['code'], $ignore) === true) {

--- a/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -227,12 +227,14 @@ class PEAR_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sni
                 $matches = array();
                 preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
 
-                $typeLen   = strlen($matches[1]);
-                $type      = trim($matches[1]);
-                $typeSpace = ($typeLen - strlen($type));
-                $typeLen   = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
+                if (empty($matches) === false) {
+                    $typeLen   = strlen($matches[1]);
+                    $type      = trim($matches[1]);
+                    $typeSpace = ($typeLen - strlen($type));
+                    $typeLen   = strlen($type);
+                    if ($typeLen > $maxType) {
+                        $maxType = $typeLen;
+                    }
                 }
 
                 if (isset($matches[2]) === true) {

--- a/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -70,7 +70,13 @@ class PEAR_Sniffs_Functions_ValidDefaultValueSniff implements PHP_CodeSniffer_Sn
                 continue;
             }
 
-            $argHasDefault = self::_argHasDefault($phpcsFile, $nextArg);
+            $argHasDefault = false;
+
+            $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextArg + 1), null, true);
+            if ($tokens[$next]['code'] === T_EQUAL) {
+                $argHasDefault = true;
+            }
+
             if ($argHasDefault === false && $defaultFound === true) {
                 $error = 'Arguments with default values must be at the end of the argument list';
                 $phpcsFile->addError($error, $nextArg, 'NotAtEnd');
@@ -79,32 +85,22 @@ class PEAR_Sniffs_Functions_ValidDefaultValueSniff implements PHP_CodeSniffer_Sn
 
             if ($argHasDefault === true) {
                 $defaultFound = true;
+                // Check if the arg is type hinted and using NULL for the default.
+                // This does not make the argument optional - it just allows NULL
+                // to be passed in.
+                $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($next + 1), null, true);
+                if ($tokens[$next]['code'] === T_NULL) {
+                    $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextArg - 1), null, true);
+                    if ($tokens[$prev]['code'] === T_STRING
+                        || $tokens[$prev]['code'] === T_ARRAY_HINT
+                    ) {
+                        $defaultFound = false;
+                    }
+                }
             }
-        }
+        }//end while
 
     }//end process()
-
-
-    /**
-     * Returns true if the passed argument has a default value.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $argPtr    The position of the argument
-     *                                        in the stack.
-     *
-     * @return bool
-     */
-    private static function _argHasDefault(PHP_CodeSniffer_File $phpcsFile, $argPtr)
-    {
-        $tokens    = $phpcsFile->getTokens();
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($argPtr + 1), null, true);
-        if ($tokens[$nextToken]['code'] !== T_EQUAL) {
-            return false;
-        }
-
-        return true;
-
-    }//end _argHasDefault()
 
 
 }//end class

--- a/pear/PHP/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,6 +27,12 @@
  */
 class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
 {
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
 
 
     /**
@@ -56,6 +62,13 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
+        }
+
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             return;
@@ -72,7 +85,7 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->recordMetric($stackPtr, 'One class per file', 'yes');
         }
 
-        if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+        if ($this->_phpVersion >= 50300) {
             $namespace = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
             if ($tokens[$namespace]['code'] !== T_NAMESPACE) {
                 $error = 'Each %s must be in a namespace of at least one level (a top-level vendor name)';

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -69,14 +69,27 @@ class Squiz_Sniffs_CSS_DuplicateClassDefinitionSniff implements PHP_CodeSniffer_
             return;
         }
 
+        // Save the class names in a "scope",
+        // to prevent false positives with @media blocks.
+        $scope = 'main';
+
         $find = array(
                  T_CLOSE_CURLY_BRACKET,
+                 T_OPEN_CURLY_BRACKET,
                  T_COMMENT,
                  T_OPEN_TAG,
                 );
 
         while ($next !== false) {
             $prev = $phpcsFile->findPrevious($find, ($next - 1));
+
+            // Check if an inner block was closed.
+            $beforePrev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prev - 1), null, true);
+            if ($beforePrev !== false
+                && $tokens[$beforePrev]['code'] === T_CLOSE_CURLY_BRACKET
+            ) {
+                $scope = 'main';
+            }
 
             // Create a sorted name for the class so we can compare classes
             // even when the individual names are all over the place.
@@ -94,13 +107,16 @@ class Squiz_Sniffs_CSS_DuplicateClassDefinitionSniff implements PHP_CodeSniffer_
             sort($names);
             $name = implode(',', $names);
 
-            if (isset($classNames[$name]) === true) {
-                $first = $classNames[$name];
+            if ($name{0} === '@') {
+                // Media block has its own "scope".
+                $scope = $name;
+            } else if (isset($classNames[$scope][$name]) === true) {
+                $first = $classNames[$scope][$name];
                 $error = 'Duplicate class definition found; first defined on line %s';
                 $data  = array($tokens[$first]['line']);
                 $phpcsFile->addError($error, $next, 'Found', $data);
             } else {
-                $classNames[$name] = $next;
+                $classNames[$scope][$name] = $next;
             }
 
             $next = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($next + 1));

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -32,6 +32,13 @@ if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
 class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
 {
 
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
+
 
     /**
      * Process the return comment of this function comment.
@@ -238,6 +245,13 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
      */
     protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         $params  = array();
@@ -258,12 +272,14 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                 $matches = array();
                 preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
 
-                $typeLen   = strlen($matches[1]);
-                $type      = trim($matches[1]);
-                $typeSpace = ($typeLen - strlen($type));
-                $typeLen   = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
+                if (empty($matches) === false) {
+                    $typeLen   = strlen($matches[1]);
+                    $type      = trim($matches[1]);
+                    $typeSpace = ($typeLen - strlen($type));
+                    $typeLen   = strlen($type);
+                    if ($typeLen > $maxType) {
+                        $maxType = $typeLen;
+                    }
                 }
 
                 if (isset($matches[2]) === true) {
@@ -380,7 +396,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                         $suggestedTypeHint = 'callable';
                     } else if (in_array($typeName, PHP_CodeSniffer::$allowedTypes) === false) {
                         $suggestedTypeHint = $suggestedName;
-                    } else if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+                    } else if ($this->_phpVersion >= 70000) {
                         if ($typeName === 'string') {
                             $suggestedTypeHint = 'string';
                         } else if ($typeName === 'int' || $typeName === 'integer') {

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -59,7 +59,16 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
      *
      * @var int
      */
-    protected $lineLimit = 20;
+    public $lineLimit = 20;
+
+    /**
+     * The format the end comment should be in.
+     *
+     * The placeholder %s will be replaced with the type of condition opener.
+     *
+     * @var string
+     */
+    public $commentFormat = '//end %s';
 
 
     /**
@@ -102,7 +111,7 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
         }
 
         if ($startCondition['code'] === T_IF) {
-            // If this is actually and ELSE IF, skip it as the brace
+            // If this is actually an ELSE IF, skip it as the brace
             // will be checked by the original IF.
             $else = $phpcsFile->findPrevious(T_WHITESPACE, ($tokens[$stackPtr]['scope_condition'] - 1), null, true);
             if ($tokens[$else]['code'] === T_ELSE) {
@@ -158,7 +167,7 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
 
         $lineDifference = ($endBrace['line'] - $startBrace['line']);
 
-        $expected = '//end '.$startCondition['content'];
+        $expected = sprintf($this->commentFormat, $startCondition['content']);
         $comment  = $phpcsFile->findNext(array(T_COMMENT), $stackPtr, null, false);
 
         if (($comment === false) || ($tokens[$comment]['line'] !== $endBrace['line'])) {

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -45,14 +45,21 @@ class Squiz_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Stand
      */
     public function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens       = $phpcsFile->getTokens();
-        $commentToken = array(
-                         T_COMMENT,
-                         T_DOC_COMMENT_CLOSE_TAG,
-                        );
+        $tokens = $phpcsFile->getTokens();
+        $ignore = array(
+                   T_PUBLIC,
+                   T_PRIVATE,
+                   T_PROTECTED,
+                   T_VAR,
+                   T_STATIC,
+                   T_WHITESPACE,
+                  );
 
-        $commentEnd = $phpcsFile->findPrevious($commentToken, $stackPtr);
-        if ($commentEnd === false) {
+        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        if ($commentEnd === false
+            || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT)
+        ) {
             $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
             return;
         }
@@ -60,16 +67,6 @@ class Squiz_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Stand
         if ($tokens[$commentEnd]['code'] === T_COMMENT) {
             $phpcsFile->addError('You must use "/**" style comments for a member variable comment', $stackPtr, 'WrongStyle');
             return;
-        } else if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
-            $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
-            return;
-        } else {
-            // Make sure the comment we have found belongs to us.
-            $commentFor = $phpcsFile->findNext(array(T_VARIABLE, T_CLASS, T_INTERFACE), ($commentEnd + 1));
-            if ($commentFor !== $stackPtr) {
-                $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
-                return;
-            }
         }
 
         $commentStart = $tokens[$commentEnd]['comment_opener'];
@@ -126,7 +123,11 @@ class Squiz_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Stand
                       $suggestedType,
                       $varType,
                      );
-            $phpcsFile->addError($error, ($foundVar + 2), 'IncorrectVarType', $data);
+
+            $fix = $phpcsFile->addFixableError($error, ($foundVar + 2), 'IncorrectVarType', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($foundVar + 2), $suggestedType);
+            }
         }
 
     }//end processMemberVar()

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -109,6 +109,25 @@ class Squiz_Sniffs_Formatting_OperatorBracketSniff implements PHP_CodeSniffer_Sn
             }
         }//end if
 
+        // Tokens that are allowed inside a bracketed operation.
+        $allowed = array(
+                    T_VARIABLE,
+                    T_LNUMBER,
+                    T_DNUMBER,
+                    T_STRING,
+                    T_WHITESPACE,
+                    T_THIS,
+                    T_SELF,
+                    T_OBJECT_OPERATOR,
+                    T_DOUBLE_COLON,
+                    T_OPEN_SQUARE_BRACKET,
+                    T_CLOSE_SQUARE_BRACKET,
+                    T_MODULUS,
+                    T_NONE,
+                   );
+
+        $allowed += PHP_CodeSniffer_Tokens::$operators;
+
         $lastBracket = false;
         if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
             $parenthesis = array_reverse($tokens[$stackPtr]['nested_parenthesis'], true);
@@ -123,23 +142,8 @@ class Squiz_Sniffs_Formatting_OperatorBracketSniff implements PHP_CodeSniffer_Sn
                 }
 
                 if ($prevCode === T_STRING || $prevCode === T_SWITCH) {
-                    // We allow very simple operations to not be bracketed.
+                    // We allow simple operations to not be bracketed.
                     // For example, ceil($one / $two).
-                    $allowed = array(
-                                T_VARIABLE,
-                                T_LNUMBER,
-                                T_DNUMBER,
-                                T_STRING,
-                                T_WHITESPACE,
-                                T_THIS,
-                                T_SELF,
-                                T_OBJECT_OPERATOR,
-                                T_DOUBLE_COLON,
-                                T_OPEN_SQUARE_BRACKET,
-                                T_CLOSE_SQUARE_BRACKET,
-                                T_MODULUS,
-                               );
-
                     for ($prev = ($stackPtr - 1); $prev > $bracket; $prev--) {
                         if (in_array($tokens[$prev]['code'], $allowed) === true) {
                             continue;
@@ -281,6 +285,7 @@ class Squiz_Sniffs_Formatting_OperatorBracketSniff implements PHP_CodeSniffer_Sn
                     T_MODULUS         => true,
                     T_ISSET           => true,
                     T_ARRAY           => true,
+                    T_NONE            => true,
                    );
 
         // Find the first token in the expression.

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -198,13 +198,14 @@ class Squiz_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff implements 
                 }
             }
 
-            // Take references into account when expecting the
-            // location of whitespace.
             $checkToken = ($nextParam - 1);
-            if ($tokens[$checkToken]['code'] === T_ELLIPSIS) {
-                $checkToken--;
+            $prev       = $phpcsFile->findPrevious(T_WHITESPACE, $checkToken, null, true);
+            if ($tokens[$prev]['code'] === T_ELLIPSIS) {
+                $checkToken = ($prev - 1);
             }
 
+            // Take references into account when expecting the
+            // location of whitespace.
             if ($phpcsFile->isReference($checkToken) === true) {
                 $whitespace = ($checkToken - 1);
             } else {

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -154,7 +154,7 @@ class Squiz_Sniffs_Operators_ComparisonOperatorUsageSniff implements PHP_CodeSni
 
                 $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($i + 1), null, true);
             } else {
-                if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+                if (isset($tokens[$end]['parenthesis_opener']) === false) {
                     return;
                 }
 

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -38,7 +38,7 @@ class Squiz_Sniffs_Scope_MethodScopeSniff extends PHP_CodeSniffer_Standards_Abst
      */
     public function __construct()
     {
-        parent::__construct(array(T_CLASS, T_INTERFACE), array(T_FUNCTION));
+        parent::__construct(array(T_CLASS, T_INTERFACE, T_TRAIT), array(T_FUNCTION));
 
     }//end __construct()
 

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -69,7 +69,9 @@ class Squiz_Sniffs_Strings_DoubleQuoteUsageSniff implements PHP_CodeSniffer_Snif
 
         $i = ($stackPtr + 1);
         if (isset($tokens[$i]) === true) {
-            while ($tokens[$i]['code'] === $tokens[$stackPtr]['code']) {
+            while ($i < $phpcsFile->numTokens
+                && $tokens[$i]['code'] === $tokens[$stackPtr]['code']
+            ) {
                 $workingString  .= $tokens[$i]['content'];
                 $lastStringToken = $i;
                 $i++;

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -82,7 +82,7 @@ class Squiz_Sniffs_WhiteSpace_LanguageConstructSpacingSniff implements PHP_CodeS
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
                 }
             }
-        } else {
+        } else if ($tokens[($stackPtr + 1)]['code'] !== T_OPEN_PARENTHESIS) {
             $error = 'Language constructs must be followed by a single space; expected "%s" but found "%s"';
             $data  = array(
                       $tokens[$stackPtr]['content'].' '.$tokens[($stackPtr + 1)]['content'],

--- a/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/pear/PHP/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -30,6 +30,13 @@
 class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,7 +85,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
         $phpcsFile->recordMetric($stackPtr, 'Spacing before object operator', $before);
         $phpcsFile->recordMetric($stackPtr, 'Spacing after object operator', $after);
 
-        if ($before !== 0) {
+        if ($before !== 0
+            && ($before !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found before object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before');
             if ($fix === true) {
@@ -86,7 +95,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
             }
         }
 
-        if ($after !== 0) {
+        if ($after !== 0
+            && ($after !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found after object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'After');
             if ($fix === true) {

--- a/pear/PHP/CodeSniffer/Tokenizers/PHP.php
+++ b/pear/PHP/CodeSniffer/Tokenizers/PHP.php
@@ -923,7 +923,6 @@ class PHP_CodeSniffer_Tokenizers_PHP
                 // the parenthesis map clean, so let's tag these tokens as
                 // T_ARRAY_HINT.
                 if ($newToken['code'] === T_ARRAY) {
-                    // Recalculate number of tokens.
                     for ($i = $stackPtr; $i < $numTokens; $i++) {
                         if ($tokens[$i] === '(') {
                             break;

--- a/readme_moodle.txt
+++ b/readme_moodle.txt
@@ -8,7 +8,7 @@ Instructions to upgrade the phpcs bundled version:
 
 Current checkout:
 
-  2.6.2 (4edb770)
+  2.7.0 (571e27b)
 
 Local modifications (only allowed if there is a PR upstream backing it):
 


### PR DESCRIPTION
First change in order to get a new release before 3.2... note that travis is facing some problem since some days ago and jobs don't end properly:

https://github.com/travis-ci/travis-ci/issues/6861

But if you look to results, everything is passing ok.