### PR TITLE
Consider new lines as valid characters after operators

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -50,7 +50,11 @@
     <rule ref="Squiz.Scope.MethodScope"/>
     <rule ref="Squiz.Scope.StaticThisUsage"/>
 
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>

--- a/moodle/tests/fixtures/squiz_whitespace_operatorspacing.php
+++ b/moodle/tests/fixtures/squiz_whitespace_operatorspacing.php
@@ -45,3 +45,18 @@ $c = $a/10;
 $c = $a / 10;
 $c = $a /  10;
 $c = $a  / 10;
+
+// Operators ending in new line instead of space.
+$a = $c == 20 ?
+    "Hottest nerd there!" : "Zombies are comming";
+$a = $c == 20 ? "Hottest nerd there!" :
+    "Zombies are comming";
+$a = 200 -
+    500;
+$a = 200 +
+    500;
+$a = 200 /
+    500;
+$a = 200 *
+    500;
+

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -405,7 +405,21 @@ class moodlestandard_testcase extends local_codechecker_testcase {
                                45 => 0,
                                46 => 'Expected 1 space after "/"; 2 found',
                                47 => 'Expected 1 space before "/"; 2 found',
-
+                               48 => 0,
+                               49 => 0,
+                               50 => 0,
+                               51 => 0,
+                               52 => 0,
+                               53 => 0,
+                               54 => 0,
+                               55 => 0,
+                               56 => 0,
+                               57 => 0,
+                               58 => 0,
+                               59 => 0,
+                               60 => 0,
+                               61 => 0,
+                               62 => 0
                           ));
         $this->set_warnings(array());
 


### PR DESCRIPTION
If after an operator new line character is encountered, we should not generate warnings or notices.