### PR TITLE
MDLSITE-2825 Allow obj-op at beginning + basic indentation checks

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -55,7 +55,10 @@
             <property name="ignoreNewlines" value="true"/>
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+        <exclude name="Squiz.WhiteSpace.ObjectOperatorSpacing.Before"/>
+    </rule>
+    <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>

--- a/moodle/tests/fixtures/squiz_whitespace_objectoperatorspacing.php
+++ b/moodle/tests/fixtures/squiz_whitespace_objectoperatorspacing.php
@@ -1,0 +1,70 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All these are correct, both spacing and indent.
+$object->one()->two()->three();
+$a = $object->one()->two()->three();
+
+$object->one()->two()
+    ->three();
+$a = $object->one()->two()
+    ->three();
+
+$object->one()
+    ->two()->three();
+$a = $object->one()
+    ->two()->three();
+
+$object->one()
+    ->two()
+    ->three();
+
+$a = $object->one()
+    ->two()
+    ->three();
+
+get_object()->one()
+    ->two()
+    ->three();
+
+someclass::one()
+    ->two()
+    ->three();
+
+(new someclass())->one()
+    ->two()
+    ->three();
+
+// These have incorrect (<4) indent.
+$object->one()
+  ->two()
+  ->three();
+
+$a = $object->one()
+  ->two()
+  ->three();
+
+// These have incorrect (>4) indent.
+$object->one()
+      ->two()
+      ->three();
+
+$a = $object->one()
+      ->two()
+      ->three();
+
+// These are not detected by the indent sniff. Probably an issue with it.
+// Have tried some quick changes to PEAR_Sniffs_WhiteSpace_ObjectOperatorIndentSniff
+// trying to support this, but leads to some false positives. So, keeping unmodified.
+// More info: https://github.com/squizlabs/PHP_CodeSniffer/issues/2009
+get_object()->one()
+  ->two()
+      ->three();
+
+someclass::one()
+  ->two()
+      ->three();
+
+(new someclass())->one()
+  ->two()
+      ->three();

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -351,7 +351,7 @@ class moodlestandard_testcase extends local_codechecker_testcase {
     /**
      * Test operator spacing standards
      */
-    public function test_moodle_operator_spacing() {
+    public function test_squiz_operator_spacing() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -422,6 +422,57 @@ class moodlestandard_testcase extends local_codechecker_testcase {
                                61 => 0,
                                62 => 0
                           ));
+        $this->set_warnings(array());
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
+    /**
+     * Test object operator spacing standards
+     */
+    public function test_squiz_object_operator_spacing() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('Squiz.WhiteSpace.ObjectOperatorSpacing');
+        $this->set_fixture(__DIR__ . '/fixtures/squiz_whitespace_objectoperatorspacing.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors(array());
+        $this->set_warnings(array());
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
+    /**
+     * Test object operator indentation standards
+     */
+    public function test_pear_object_operator_indent() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('PEAR.WhiteSpace.ObjectOperatorIndent');
+        $this->set_fixture(__DIR__ . '/fixtures/squiz_whitespace_objectoperatorspacing.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors(array(
+            40 => 'not indented correctly; expected 4 spaces but found 2',
+            41 => '@Source: PEAR.WhiteSpace.ObjectOperatorIndent.Incorrect',
+            44 => 1,
+            45 => 1,
+            49 => 'not indented correctly; expected 4 spaces but found 6',
+            50 => '@Source: PEAR.WhiteSpace.ObjectOperatorIndent.Incorrect',
+            53 => 1,
+            54 => 1
+        ));
         $this->set_warnings(array());
 
         // Let's do all the hard work!


### PR DESCRIPTION
The indentation sniff (PEAR.WhiteSpace.ObjectOperatorIndent) does
not cover all the cases, just the "object" (variable) ones, so I've
created and issue @ PHP_CodeSniffer about it:

https://github.com/squizlabs/PHP_CodeSniffer/issues/2009