### PR TITLE
NOBUG: Switch to OpenJDK JRE, more stable packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
 
 cache:
   directories:


### PR DESCRIPTION
Here and there, more with other travis modes, the oracle java packages fail to download and install. We only need a JRE here, so switching to OpenJDK's one, that is ok enough for our needs.