### PR TITLE
MDLSIT-5908: respect eslint configuration comments in JS files

### DIFF
--- a/moodle/Sniffs/Commenting/InlineCommentSniff.php
+++ b/moodle/Sniffs/Commenting/InlineCommentSniff.php
@@ -365,6 +365,11 @@ class moodle_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Sni
         // within them if they are full sentences.
         $commentText = rtrim($commentText, "'\")");
 
+        // Respect eslint configuration comments in JS files.
+        if ($phpcsFile->tokenizerType === 'JS' && preg_match('!^eslint(-|\s)!', $commentText)) {
+            return;
+        }
+
         if ($commentText === '') {
             $error = 'Blank comments are not allowed';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Empty');

--- a/moodle/tests/fixtures/moodle_comenting_inlinecomment.js
+++ b/moodle/tests/fixtures/moodle_comenting_inlinecomment.js
@@ -1,0 +1,46 @@
+/// Three slashes are incorrect.
+
+//// four are also wrong. Not to talk about the missing upper and final dot
+
+//And no-space, uhm, bad, bad!
+
+// None of the following phpdocs should be causing problems.
+
+/* eslint no-unreachable: "error" */
+
+define([], function() {
+
+    /**
+     * Selector class.
+     *
+     * @param {String} title The title.
+     */
+    var Selector = function(title) {
+        var self = this;
+
+        self._title = title;
+        self._reset();
+    };
+
+    /** @type {String} The title. */
+    Selector.prototype._title = null;
+
+    /**
+     * This does not reset anything.
+     *
+     * @method _reset
+     */
+    Selector.prototype._reset = function() {
+        alert('foo'); // eslint-disable-line no-alert
+
+        // eslint-disable-next-line no-alert
+        alert('foo');
+
+        alert('foo'); /* eslint-disable-line no-alert */
+
+        /* eslint-disable-next-line no-alert */
+        alert('foo');
+    };
+
+    return Selector;
+});

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -37,7 +37,7 @@ require_once(__DIR__ . '/../../tests/local_codechecker_testcase.php');
  */
 class moodlestandard_testcase extends local_codechecker_testcase {
 
-    public function test_moodle_comenting_inlinecomment() {
+    public function test_moodle_commenting_inlinecomment() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -74,6 +74,30 @@ class moodlestandard_testcase extends local_codechecker_testcase {
            75 => 2,
            77 => 1,
            79 => 1));
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_commenting_inlinecomment_js() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Commenting.InlineComment');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_comenting_inlinecomment.js');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors(array(
+            1 => array('3 slashes comments are not allowed'),
+            3 => 1,
+            5 => 'No space found before comment text',
+        ));
+        $this->set_warnings(array(
+            3 => array(null, 'Commenting.InlineComment.InvalidEndChar'),
+        ));
 
         // Let's do all the hard work!
         $this->verify_cs_results();


### PR DESCRIPTION
When you run codechecker on JS file (this is permitted), eslint configuration comments do not pass "Inline Comments" sniff.

Tracker URL: https://tracker.moodle.org/browse/MDLSITE-5908