### PR TITLE
Move to use virtualized Travis infrastructure (xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: php
 
-sudo: required
-
 addons:
   firefox: "47.0.1"
-  postgresql: "9.4"
-  apt:
-    packages:
-      - openjdk-8-jre-headless
 
 services:
-  mysql
+  - mysql
+  - postgresql
 
 cache:
   directories:


### PR DESCRIPTION
So openjdk is available by default and postgres better defined as
service.

Trying how it goes...