### PR TITLE
MDLSITE-6093 Mono-artifact files can be MOODLE_INTERNAL free

### DIFF
--- a/moodle/tests/fixtures/moodle_files_moodleinternal/nowarning.php
+++ b/moodle/tests/fixtures/moodle_files_moodleinternal/nowarning.php
@@ -29,6 +29,4 @@
  * @copyright  2016 Frédéric Massart - FMCorz.net
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class chart_line { }
-
-trait chart_pie { }
+interface chart { }

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -586,8 +586,19 @@ class moodlestandard_testcase extends local_codechecker_testcase {
 
         $this->set_errors(array());
         $this->set_warnings(array(
-            32 => 'Expected MOODLE_INTERNAL check or config.php inclusion'
+            32 => 'Expected MOODLE_INTERNAL check or config.php inclusion. Multiple artifacts'
         ));
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_moodleinternal_nowarning() {
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_moodleinternal/nowarning.php');
+
+        $this->set_errors(array());
+        $this->set_warnings(array());
 
         $this->verify_cs_results();
     }


### PR DESCRIPTION
Decided @ https://tracker.moodle.org/browse/MDLSITE-5967 files
with only one artifact (class, interface, trait) now don't
require the MOODLE_INTERNAL check anymore (although it continues
being allowed).

Only if the file has more than 1 artifact, the warning is emited.

Errors are emited when the file has side effects (global scope code). No change there.