### PR TITLE
Allow short-options to work again (they were recently broken)

### DIFF
--- a/pear/PHP/CodeSniffer/CLI.php
+++ b/pear/PHP/CodeSniffer/CLI.php
@@ -450,7 +450,7 @@ class PHP_CodeSniffer_CLI
                 continue;
             }
 
-            if ($arg[1] === '-') {
+            if ($arg[0] === '-') {
                 if ($arg === '-' || $arg === '--') {
                     // Empty argument, ignore it.
                     continue;


### PR DESCRIPTION
One of the multiple changes added by #65 towards php74 compatibility
was wrong and, without noticing it, we broke all the CLI short options

```
phpcs [-nwlsaepqvi]
```

Normally we don't use them, so it was unnoticed. Just today I was
doing some tests using the -s option (to show information about
the Sniffs detecting some errors) and I was, surprisingly, getting:

ERROR: option "-s" not known.

And the very same with every other short option.

So, this, just fixes this change, that was clearly wrong:

https://github.com/moodlehq/moodle-local_codechecker/commit/04810acd95b734543c6af6b247e715f2060dbd53#diff-857386c2703704c8ccc54229f7861931L453-R453

keeping a correct [0] there. To verify it:

- Run: pear/PHP/scripts/phpcs -i
- Current (broken) status: ERROR: option "-i" not known.
- With the patch applied: It works a a list of standards is shown.