### PR TITLE
Enforce, from the standard, that only PHP files will be ever handled.

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -2,6 +2,8 @@
 <ruleset name="moodle">
     <description>The Moodle coding style</description>
 
+    <arg name="extensions" value="php" />
+
     <rule ref="Generic.Classes.DuplicateClassName"/>
 
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -83,6 +83,12 @@ class moodlestandard_testcase extends local_codechecker_testcase {
         $this->verify_cs_results();
     }
 
+    /**
+     * Note that, while this test continues passing, because
+     * we load the .js file manually, now the moodle standard
+     * by default enforces --extensions=php, so no .js file
+     * will be inspected by default ever.
+     */
     public function test_moodle_commenting_inlinecomment_js() {
 
         // Define the standard, sniff and fixture to use.


### PR DESCRIPTION
That way behavior will be always the same, irrespectively
of the client (codechecker, lang server, IDE, CLI...) and
only PHP file will be inspected.

Source: https://tracker.moodle.org/browse/CONTRIB-6175

To verify that the switch works, you can execute:

```
local/codechecker/pear/PHP/scripts/phpcs --standard=local/codechecker/moodle mod/forum/amd/src -v
```
- Before the patch: The .js files were inspected and a number of errors were reported.
- After the patch: No .js file is inspected anymore.