### PR TITLE
php74: Fix a couple of remaining curly-bracket uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+os: linux
+dist: xenial
+
 addons:
   firefox: "47.0.1"
 
@@ -11,109 +14,64 @@ cache:
   directories:
     - $HOME/.composer/cache
     - $HOME/.npm
+    - $HOME/.nvm
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+jobs:
+  include:
+    - php: 7.4
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
 
-env:
-  - MOODLE_BRANCH=master           DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=master           DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-  - MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql NODE=8
 
-matrix:
-  exclude:
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.4
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=master           DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=master           DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.3
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
     - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=master           DB=pgsql
     - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=master           DB=mysqli
     - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.2
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql NODE=8
+
     - php: 7.1
-      env: MOODLE_BRANCH=master           DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
     - php: 7.1
-      env: MOODLE_BRANCH=master           DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
     - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli NODE=8
     - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql NODE=8.9
+
     - php: 7.0
-      env: MOODLE_BRANCH=master           DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql NODE=8
     - php: 7.0
-      env: MOODLE_BRANCH=master           DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
     - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql NODE=8
+
     - php: 5.6
-      env: MOODLE_BRANCH=master           DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli NODE=8
     - php: 5.6
-      env: MOODLE_BRANCH=master           DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 5.6
-      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 5.6
-      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 5.6
-      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 5.6
-      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
-    - php: 5.6
-      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql  IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs BEHAT=yes
+      env: MOODLE_BRANCH=MOODLE_32_STABLE DB=pgsql NODE=8.9
 
 before_install:
-  # Get rid of the || return 0 once we switch to 7.4 with xdebug installed.
-  - phpenv config-rm xdebug.ini || return 0
-  - nvm install 8.9
-  - nvm use 8.9
+  - phpenv config-rm xdebug.ini
+  - if [ -z $NODE ]; then
+      export NODE=14;
+    fi
+  - nvm install $NODE
+  - nvm use $NODE
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+  - export IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+  - export BEHAT=yes
 
 install:
   - moodle-plugin-ci install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Changes in version 2.9.5 (20200401) - Poisson d'avril
 -----------------------------------------------------
 - CONTRIB-8024: Process all files as UTF-8 encoded (defined @ standard level).
-- CONTRIB-6175: Only process PHP file (defined @ standard level).
+- CONTRIB-6175: Only process PHP files (defined @ standard level).
 - [PR#69](https://github.com/moodlehq/moodle-local_codechecker/pull/69): Upgrade PHPCompatibility to 9.3.5+ (9fb3244).
 - CONTRIB-8031: Detect wrong uses of $PAGE and $OUTPUT in renderers and blocks (Tim Hunt).
 - MDLSITE-6093: Don't require MOODLE_INTERNAL check for pure 1-artifact (class, interface, trait) files.

--- a/pear/PHP/CodeSniffer.php
+++ b/pear/PHP/CodeSniffer.php
@@ -2025,12 +2025,12 @@ class PHP_CodeSniffer
             $lastCharWasCaps = $classFormat;
 
             for ($i = 1; $i < $length; $i++) {
-                $ascii = ord($string{$i});
+                $ascii = ord($string[$i]);
                 if ($ascii >= 48 && $ascii <= 57) {
                     // The character is a number, so it cant be a capital.
                     $isCaps = false;
                 } else {
-                    if (strtoupper($string{$i}) === $string{$i}) {
+                    if (strtoupper($string[$i]) === $string[$i]) {
                         $isCaps = true;
                     } else {
                         $isCaps = false;


### PR DESCRIPTION
These escaped #65 and just noticed them today when executing
the bundled pear/PHP/scripts/phpcs binary (not reproducible
from web or tests).

Also fix an unrelated typo in CHANGES.md

Finally, have added some important changes to travis, aiming for simplicity (include jobs instead of matrix + excludes), better nodejs handling... 