### PR TITLE
CONTRIB-8122 Stop processing non-php files (runner and UI)

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,6 +66,7 @@ if ($path) {
     if ($fullpath) {
         $reportfile = make_temp_directory('phpcs') . '/phpcs_' . random_string(10) . '.xml';
         $phpcs = new PHP_CodeSniffer();
+        $phpcs->setAllowedFileExtensions(['php']); // We are only going to process php files ever.
         $cli = new local_codechecker_codesniffer_cli();
         $cli->setReport('local_codechecker'); // Using own custom xml format for easier handling later.
         $cli->setReportFile($reportfile); // Send the report to dataroot temp.

--- a/run.php
+++ b/run.php
@@ -56,6 +56,7 @@ $standard = $CFG->dirroot . str_replace('/', DIRECTORY_SEPARATOR, '/local/codech
 
 $cli = new local_codechecker_codesniffer_cli();
 $phpcs = new PHP_CodeSniffer(1, 0, 'utf-8', $interactive);
+$phpcs->setAllowedFileExtensions(['php']); // We are only going to process php files ever.
 $phpcs->setCli($cli);
 $phpcs->setIgnorePatterns(local_codesniffer_get_ignores());
 $phpcs->process(local_codechecker_clean_path(


### PR DESCRIPTION
While @ https://tracker.moodle.org/browse/CONTRIB-6175 we
defined at standard level that only php files should be ever
processed, it seems that only the "phpcs" binary observes that
setting.

Both the custom run.php script and the moodle plugin (UI) are
not informed of this so they continue processing other files.

This commit just ensures they stop doing that and, from now on
only PHP files will be processed.