### PR TITLE
Add a hand of missing codes that are mandatory in phpcs3

### DIFF
--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -75,12 +75,14 @@ class moodle_Sniffs_Files_MoodleInternalSniff implements PHP_CodeSniffer_Sniff {
 
         // Got here because, so something is not right.
         if ($this->code_changes_global_state($file, $pointer, ($file->numTokens - 1))) {
-            $file->addError('Expected MOODLE_INTERNAL check or config.php inclusion. Change in global state detected.', $pointer);
+            $file->addError('Expected MOODLE_INTERNAL check or config.php inclusion. Change in global state detected.',
+                $pointer, 'MoodleInternalGlobalState');
         } else {
             // Only if there are more than one artifact (class, interface, trait), we show the warning.
             // (files with only one, are allowed to be MOODLE_INTERNAL free - MDLSITE-5967).
             if ($this->count_artifacts($file) > 1) {
-                $file->addWarning('Expected MOODLE_INTERNAL check or config.php inclusion. Multiple artifacts detected.', $pointer);
+                $file->addWarning('Expected MOODLE_INTERNAL check or config.php inclusion. Multiple artifacts detected.',
+                    $pointer, 'MoodleInternalMultipleArtifacts');
             }
         }
     }

--- a/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -52,14 +52,14 @@ class moodle_Sniffs_NamingConventions_ValidVariableNameSniff
 
         if (preg_match('/[A-Z]+/', $membername)) {
             $error = "Member variable \"$membername\" must be all lower-case";
-            $phpcsfile->addError($error, $stackptr);
+            $phpcsfile->addError($error, $stackptr, 'MemberNameLowerCase');
         }
 
         // Find underscores in variable names (accepting $_foo for private vars).
         $pos = strpos($membername, '_');
         if ($pos > 1) {
             $error = "Member variable \"$membername\" must not contain underscores.";
-            $phpcsfile->addError($error, $stackptr);
+            $phpcsfile->addError($error, $stackptr, 'MemberNameUnderscore');
         }
 
         // Must not be preceded by 'var' keyword.
@@ -68,7 +68,7 @@ class moodle_Sniffs_NamingConventions_ValidVariableNameSniff
         if ($tokens[$keyword]['line'] == $tokens[$stackptr]['line']) {
             $error = "The 'var' keyword is not permitted." .
                      'Visibility must be explicitly declared with public, private or protected';
-            $phpcsfile->addError($error, $stackptr);
+            $phpcsfile->addError($error, $stackptr, 'MemberNameVisibility');
         }
     }
 
@@ -118,12 +118,12 @@ class moodle_Sniffs_NamingConventions_ValidVariableNameSniff
     private function validate_moodle_variable_name($varname, PHP_CodeSniffer_File $phpcsfile, $stackptr) {
         if (preg_match('/[A-Z]+/', $varname) && !in_array($varname, self::$allowedglobals)) {
             $error = "Variable \"$varname\" must be all lower-case";
-            $phpcsfile->addError($error, $stackptr);
+            $phpcsfile->addError($error, $stackptr, 'VariableNameLowerCase');
         }
 
         if (strpos($varname, '_') !== false && !in_array($varname, self::$allowedglobals)) {
             $error = "Variable \"$varname\" must not contain underscores.";
-            $phpcsfile->addError($error, $stackptr);
+            $phpcsfile->addError($error, $stackptr, 'VariableNameUnderscore');
         }
     }
 }


### PR DESCRIPTION
Not much to say. In phpcs these are optional, but in phpcs3 they are mandatory. And also they help to find stuff easily when reported. So better have the detail ready for whenever migrating to phpcs3.