### PR TITLE
Remove require of now-deleted coursecatlib.php

### DIFF
--- a/moodle/tests/fixtures/moodle_files_moodleinternal/old_style_if_die_ok.php
+++ b/moodle/tests/fixtures/moodle_files_moodleinternal/old_style_if_die_ok.php
@@ -26,7 +26,6 @@ if (!defined('MOODLE_INTERNAL')) {
 }
 
 require_once($CFG->libdir.'/formslib.php');
-require_once($CFG->libdir.'/coursecatlib.php');
 
 /**
  * A form for a user to request a course.


### PR DESCRIPTION
MDL-69238 finally removes lib/coursecatlib.php so might as well remove any inclusion of this file in the local_codechecker plugin (even if the only inclusion of this file is in a fixture file that doesn't really end up including any file).
