### PR TITLE
Migrate from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Moodle Code Checker
 ===================
 
-[![Build Status](https://travis-ci.org/moodlehq/moodle-local_codechecker.svg?branch=master)](https://travis-ci.org/moodlehq/moodle-local_codechecker)
+[![Build Status](https://travis-ci.com/moodlehq/moodle-local_codechecker.svg?branch=master)](https://travis-ci.com/moodlehq/moodle-local_codechecker)
 
 Information
 -----------


### PR DESCRIPTION
More info available @ https://tracker.moodle.org/browse/MDLSITE-6246

Note the [repo has been already migrated](https://travis-ci.com/github/moodlehq/moodle-local_codechecker), this just updates references to the new one.