### PR TITLE
Allow a list of files to be checked

### DIFF
--- a/lang/en/local_codechecker.php
+++ b/lang/en/local_codechecker.php
@@ -45,13 +45,14 @@ $string['filesfound'] = 'Files found: {$a}';
 $string['filesummary'] = '{$a->path} - {$a->count}';
 $string['info'] = '<p>Checks code against some aspects of the {$a->link}.</p>
 <p>Enter a path relative to the Moodle code root, for example: {$a->path}.</p>
-<p>You can enter either a specific PHP file, or to a folder to check all the files it contains.</p>
+<p>You can enter either a specific PHP file, or to a folder to check all the files it contains.
+Multiple entries are supported (files or folders), one per line.</p>
 <p>To exclude files, a comma separated list of substr matching paths can be used, for example: {$a->excludeexample}. Asterisks are allowed as wildchars at any place.</p>';
 $string['includewarnings'] = 'Include warnings';
 $string['invalidpath'] = 'Invalid path {$a}';
 $string['moodlecodingguidelines'] = 'Moodle coding guidelines';
 $string['numerrorswarnings'] = '{$a->errors} error(s) and {$a->warnings} warning(s)';
-$string['path'] = 'Path to check';
+$string['path'] = 'Path(s) to check';
 $string['privacy:metadata'] = 'The Code checker plugin does not store any personal data.';
 $string['pluginname'] = 'Code checker';
 $string['recheckfile'] = 'Re-check just this file';

--- a/locallib.php
+++ b/locallib.php
@@ -45,8 +45,8 @@ class local_codechecker_form extends moodleform {
         $a->excludeexample = html_writer::tag('tt', 'db, backup/*1, *lib*');
         $mform->addElement('static', '', '', get_string('info', 'local_codechecker', $a));
 
-        $mform->addElement('text', 'path', get_string('path', 'local_codechecker'), array('size' => '48'));
-        $mform->setType('path', PARAM_PATH);
+        $mform->addElement('textarea', 'path', get_string('path', 'local_codechecker'), ['rows' => '4', 'cols' => 48]);
+        $mform->setType('path', PARAM_RAW);
         $mform->addRule('path', null, 'required', null, 'client');
 
         $mform->addElement('text', 'exclude', get_string('exclude', 'local_codechecker'), array('size' => '48'));

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -7,7 +7,7 @@ Feature: Codechecker UI works as expected
   Scenario Outline: Verify that specified paths are checked
     Given I log in as "admin"
     And I navigate to "Development > Code checker" in site administration
-    And I set the field "Path to check" to "<path>"
+    And I set the field "Path(s) to check" to "<path>"
     And I set the field "Exclude" to "*/tests/fixtures/*"
     When I press "Check code"
     Then I should see "<seen>"
@@ -31,7 +31,7 @@ Feature: Codechecker UI works as expected
   Scenario Outline: Verify that specified exclusions are performed
     Given I log in as "admin"
     And I navigate to "Development > Code checker" in site administration
-    And I set the field "Path to check" to "<path>"
+    And I set the field "Path(s) to check" to "<path>"
     And I set the field "Exclude" to "<exclude>"
     When I press "Check code"
     Then I should see "<seen>"
@@ -50,10 +50,10 @@ Feature: Codechecker UI works as expected
 
   # We use the @javascript tag here because of MDL-53083, causing non-javascript to fail unchecking checkboxes
   @javascript
-  Scenario: Verify that the warnings toogle has effect
+  Scenario: Verify that the warnings toggle has effect
     Given I log in as "admin"
     And I navigate to "Development > Code checker" in site administration
-    And I set the field "Path to check" to "local/codechecker/moodle/tests/fixtures/squiz_php_commentedoutcode.php"
+    And I set the field "Path(s) to check" to "local/codechecker/moodle/tests/fixtures/squiz_php_commentedoutcode.php"
     And I set the field "Exclude" to "dont_exclude_anything"
     # Warnings enabled
     And I set the field "Include warnings" to "1"
@@ -68,3 +68,11 @@ Feature: Codechecker UI works as expected
     And I should not see "Inline comments must start"
     And I should not see "is this commented out code"
     And I log out
+
+  Scenario: Verify that multiple paths work
+    Given I log in as "admin"
+    And I navigate to "Development > Code checker" in site administration
+    And I set the field "Path(s) to check" to "local/codechecker/version.php\nlocal/codechecker/index.php"
+    When I press "Check code"
+    Then I should see "index.php"
+    And I should see "version.php"


### PR DESCRIPTION
Here's a simple change that lets you paste in a list of files to the textarea. It's super useful if checking files manually, because you can just do 'git show --name-only' on your commit, and then paste in the list of files to check.

I also increased the time limit to 600 because checking is so slow nowadays (which actually, is why it's often more useful to check a list of files rather than a whole folder at once - although often you also want to check files from multiple folders).