### PR TITLE
Add constants for default severity levels of warnings and errors

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -26,6 +26,16 @@ defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->libdir . '/formslib.php');
 
+// Default errors severity level
+if (defined('PHPCS_DEFAULT_ERROR_SEV') === false) {
+    define('PHPCS_DEFAULT_ERROR_SEV', 5);
+}
+
+// Default warnings severity level
+if (defined('PHPCS_DEFAULT_WARN_SEV') === false) {
+    define('PHPCS_DEFAULT_WARN_SEV', 5);
+}
+
 /**
  * Settings form for the code checker.
  *


### PR DESCRIPTION
The constants PHPCS_DEFAULT_ERROR_SEV and PHPCS_DEFAULT_WARN_SEV were defined in Codesniffer.php file, removed in phpcs3.
They are not used anymore in phpcs3, but they are still being used in locallib.php. We can change the constants to the default int value for errors and warnings severity level (5) but my personal take is that the code is easier to understand if we keep the constants.