### PR TITLE
Allow www.gnu.org be referred to via https protocol in the boilerplate

### DIFF
--- a/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -86,7 +86,12 @@ class moodle_Sniffs_Files_BoilerplateCommentSniff implements PHP_CodeSniffer_Sni
                 return;
             }
 
-            $regex = str_replace('Moodle', '.*', '/^' . preg_quote($line, '/') . '/');
+            $regex = str_replace(
+                ['Moodle', 'http\\:'],
+                ['.*', 'https?\\:'],
+                '/^' . preg_quote($line, '/') . '/'
+            );
+
             if ($tokens[$tokenptr]['code'] != T_COMMENT ||
                     !preg_match($regex, $tokens[$tokenptr]['content'])) {
 

--- a/moodle/tests/fixtures/moodle_files_boilerplate/gnu_http.php
+++ b/moodle/tests/fixtures/moodle_files_boilerplate/gnu_http.php
@@ -1,0 +1,15 @@
+<?php
+// This file is part of Code-checker plugin for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.

--- a/moodle/tests/fixtures/moodle_files_boilerplate/gnu_https.php
+++ b/moodle/tests/fixtures/moodle_files_boilerplate/gnu_https.php
@@ -1,0 +1,15 @@
+<?php
+// This file is part of Code-checker plugin for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -863,4 +863,34 @@ class moodlestandard_testcase extends local_codechecker_testcase {
 
         $this->verify_cs_results();
     }
+
+    /**
+     * Assert that www.gnu.org can be referred to via http URL in the boilerplate.
+     */
+    public function test_moodle_files_boilerplate_gnu_http() {
+
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.BoilerplateComment');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_boilerplate/gnu_http.php');
+
+        $this->set_errors([]);
+        $this->set_warnings([]);
+
+        $this->verify_cs_results();
+    }
+
+    /**
+     * Assert that www.gnu.org can be referred to via https URL in the boilerplate.
+     */
+    public function test_moodle_files_boilerplate_gnu_https() {
+
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.BoilerplateComment');
+        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_boilerplate/gnu_https.php');
+
+        $this->set_errors([]);
+        $this->set_warnings([]);
+
+        $this->verify_cs_results();
+    }
 }


### PR DESCRIPTION
As per https://www.gnu.org/licenses/gpl-faq.en.html the recommended text is

```
You should have received a copy of the GNU General Public License along with this program;
if not, see <https://www.gnu.org/licenses>.
```

and the plugin skeleton generator is using this https URL now when generating boilerplates. As noticed by @adpe in https://github.com/mudrd8mz/moodle-tool_pluginskel/commit/d57c890cbb6f1180aa82c88cf340142b71f18573#commitcomment-43416888 this is raising false failure in moodle-plugin-ci.

The patch makes the boilerplace check tolerant to having `https://` in all `http://` links in the boilerplate.