### PR TITLE
PHPUnit 8 compatibility, keeping PHPUnit 6 working for old branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ jobs:
       env: MOODLE_BRANCH=MOODLE_38_STABLE  DB=pgsql
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_37_STABLE  DB=mysqli
-    - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_33_STABLE  DB=mysqli
-    - php: 7.1
-      env: MOODLE_BRANCH=MOODLE_32_STABLE  DB=pgsql NODE_VERSION=8.9
+
+    # Cannot test with Moodle 3.2 and 3.3 any more because the new composer 2
+    # does require all components to be named properly (case-sensitively) and
+    # those branches have phpunit/Dbunit, failing. See MDL-64725.
 
     # Cannot test with PHP 7.0 any more because we are now using the :void return type.
     # Note that, still, the plugin will work ok, it's just the phpunit tests which cannot

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,9 @@ jobs:
     - php: 7.1
       env: MOODLE_BRANCH=MOODLE_32_STABLE  DB=pgsql NODE_VERSION=8.9
 
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_36_STABLE  DB=pgsql
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_35_STABLE  DB=mysqli
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_34_STABLE  DB=pgsql
+    # Cannot test with PHP 7.0 any more because we are now using the :void return type.
+    # Note that, still, the plugin will work ok, it's just the phpunit tests which cannot
+    # be executed with that PHP versions.
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/tests/local_codechecker_testcase.php
+++ b/tests/local_codechecker_testcase.php
@@ -205,7 +205,7 @@ abstract class local_codechecker_testcase extends conditional_PHPUnit_Framework_
      * In charge of initializing the CS and reset all the internal
      * properties.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         if (self::$phpcs === null) {
             // Note that the plugin workarounds this by using
             // {@link local_codechecker_codesniffer_cli} with overridden method, but I want
@@ -320,8 +320,14 @@ abstract class local_codechecker_testcase extends conditional_PHPUnit_Framework_
             // Now verify every expectation requiring matching.
             foreach ($expectation as $key => $expectedcontent) {
                 if (is_string($expectedcontent)) {
-                    $this->assertContains($expectedcontent, $results[$line][$key],
+                    // PHPUnit 6 compatibility hack. TODO: Remove once Moodle 3.5 goes out of support.
+                    if (method_exists($this, 'assertStringContainsString')) {
+                        $this->assertStringContainsString($expectedcontent, $results[$line][$key],
                             'Failed contents matching of ' . $type . ' for element ' . ($key + 1) . ' of line ' . $line . '.');
+                    } else {
+                        $this->assertContains($expectedcontent, $results[$line][$key],
+                            'Failed contents matching of ' . $type . ' for element ' . ($key + 1) . ' of line ' . $line . '.');
+                    }
                 }
             }
             // Delete this line from results.


### PR DESCRIPTION
Has a TODO to remove the conditional code once Moodle 3.5 (that is
the only branch using PHPUnit 6) becomes 100% out of support.

Because of the :void return types... PHP 7.0 is left out, as far
as it doesn't support them.

Note that this change is already in the phpcs3 branch, so maybe it
will conflict on next rebase (or maybe no) :-) 