### PR TITLE
Unlock the session before processing files

### DIFF
--- a/index.php
+++ b/index.php
@@ -67,6 +67,9 @@ $output = $PAGE->get_renderer('local_codechecker');
 echo $OUTPUT->header();
 
 if ($pathlist) {
+    // Unlock the session before processing the files.
+    \core\session\manager::write_close();
+
     $paths = preg_split('~[\r\n]+~', $pathlist);
 
     $failed = false;


### PR DESCRIPTION
There is no apparent reason to lock the session while processing the files, as no data needs to be persisted back to the session.