### PR TITLE
Bump to 2020110200 (v3.0.0) - Welcome phpcs 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-Changes in version 3.0.0 (20201102) - Welcome phpcs 3
+Changes in version 3.0.0 (20201127) - Welcome phpcs 3
 -----------------------------------------------------
 - Upgrade to PHP_CodeSniffer 3.5.8 (stronk7):
     - PHP_CodeSniffer move to phpcs directory (see readme_moodle.txt for complete instructions).

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2020111400;
-$plugin->release   = '3.0.0beta';
-$plugin->maturity  = MATURITY_BETA;
+$plugin->version   = 2020112700;
+$plugin->release   = '3.0.0';
+$plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2017111300; // Moodle 3.4 release and upwards.
 $plugin->component = 'local_codechecker';


### PR DESCRIPTION
Maturity set from beta to stable.