### PR TITLE
Login in dockerhub when possible to avoid pull limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,13 @@ before_install:
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
   - export IGNORE_PATHS=moodle/tests/fixtures,moodle/Sniffs
+  - >
+    if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_TOKEN" ]; then
+        echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
+        echo "Using authenticated connection (no pull limits)"
+    else
+        echo "Using unauthenticated docker (pull limits may apply). Setup DOCKER_USER and DOCKER_TOKEN if needed."
+    fi
 
 install:
   - moodle-plugin-ci install


### PR DESCRIPTION
With current pull limits @ dockerhub, it's possible to get failed
jobs just running 2-3 builds (each one having a good number of jobs).

With this patch, if both DOCKER_USER and DOCKER_TOKEN are defined
as environmental variables, they will be used to perform a login
to dockerhub, getting rid of pull limits.