### PR TITLE
Apply for standard abstract/final/static positioning

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -51,6 +51,7 @@
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
 
     <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
+    <rule ref="PSR2.Methods.MethodDeclaration"/>
 
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.CommentedOutCode">

--- a/moodle/tests/fixtures/psr2_methods_methoddeclaration.php
+++ b/moodle/tests/fixtures/psr2_methods_methoddeclaration.php
@@ -1,0 +1,50 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
+
+// These are ok declarations. https://www.php-fig.org/psr/psr-12/#46-abstract-final-and-static .
+abstract class goodclass {
+    private function private_function() { }
+    protected function protected_function() { }
+    public function public_function() { }
+
+    private static function private_static_function() { }
+    protected static function protected_static_function() { }
+    public static function public_static_function() { }
+
+    final private function final_private_function() { }
+    final protected function final_protected_function() { }
+    final public function final_public_function() { }
+
+    final private static function final_private_static_function() { }
+    final protected static function final_protected_static_function() { }
+    final public static function final_public_static_function() { }
+
+    abstract protected function abstract_protected_function();
+    abstract public function abstract_public_function();
+
+    abstract protected static function abstract_protected_static_function();
+    abstract public static function abstract_public_static_function();
+}
+
+// These are wrong declarations.
+abstract class badclass {
+    static private function private_static_function() { }
+    static protected function protected_static_function() { }
+    static public function public_static_function() { }
+
+    private final function final_private_function() { }
+    protected final function final_protected_function() { }
+    public final function final_public_function() { }
+
+    static private final function final_private_static_function() { }
+    static protected final function final_protected_static_function() { }
+    static public final function final_public_static_function() { }
+
+    protected abstract function abstract_protected_function();
+    public abstract function abstract_public_function();
+
+    static protected abstract function abstract_protected_static_function();
+    static public abstract function abstract_public_static_function();
+}

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -39,6 +39,37 @@ require_once(__DIR__ . '/../../tests/local_codechecker_testcase.php');
  */
 class moodlestandard_testcase extends local_codechecker_testcase {
 
+    public function test_psr2_methods_methoddeclaration() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('PSR2.Methods.MethodDeclaration');
+        $this->set_fixture(__DIR__ . '/fixtures/psr2_methods_methoddeclaration.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors(array(
+            33 => 'The static declaration must come after the visibility',
+            34 => 1,
+            35 => 1,
+            37 => 'The final declaration must precede the visibility',
+            38 => 1,
+            39 => 1,
+            41 => array('FinalAfterVisibility', 'StaticBeforeVisibility'),
+            42 => 2,
+            43 => 2,
+            45 => 'The abstract declaration must precede the visibility',
+            46 => 1,
+            48 => array('AbstractAfterVisibility', 'StaticBeforeVisibility'),
+            49 => 2));
+        $this->set_warnings(array());
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
     public function test_moodle_commenting_inlinecomment() {
 
         // Define the standard, sniff and fixture to use.

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -42,7 +42,7 @@ Feature: Codechecker UI works as expected
       | path                            | exclude            | seen                          | notseen      |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 1                | Invalid path |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | moodlestandard_test.php       | Invalid path |
-      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 8                | Invalid path |
+      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 9                | Invalid path |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Line 1 of the opening comment | moodle_php   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |


### PR DESCRIPTION
Not defined by moodle coding standard, hence not contradicting it,
let's apply fallback to PSR-12:

https://www.php-fig.org/psr/psr-12/#46-abstract-final-and-static

Using the PSR-12 Sniff and covered by tests.

Fixes #138