### PR TITLE
Add coverage info (and related Sniff)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: PHPUnit tests
         if: ${{ always() }}
-        run: moodle-plugin-ci phpunit
+        run: moodle-plugin-ci phpunit --coverage-text
 
       - name: Behat features
         if: ${{ always() }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,5 +91,5 @@ script:
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
   - moodle-plugin-ci phpdoc
-  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci phpunit --coverage-text
   - moodle-plugin-ci behat

--- a/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
+++ b/moodle/tests/fixtures/moodle_comenting_inlinecomment.php
@@ -113,3 +113,19 @@ foreach ($cms as $cm) {
 foreach ($cms as $something) {
     echo 'This is a test';
 }
+
+// Allow phpdoc before "return new class extends" expressions.
+/** This is a phpdoc block */
+return new class extends xxxx {}
+
+// But don't allow it before other expressions.
+/** This is a phpdoc block */
+return new stdClass();
+/** This is a phpdoc block */
+return new class {}
+/** This is a phpdoc block */
+return class extends xxxx {}
+/** This is a phpdoc block */
+new class testphpdoc {}
+/** This is a phpdoc block */
+return new class implements something {}

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -92,7 +92,13 @@ class moodlestandard_testcase extends local_codechecker_testcase {
            91 => '\'$variable\' does not match next code line \'lets_execute_it...\'',
            94 => 1,
           102 => '\'$cm\' does not match next list() variables @Source: moodle.Commenting.InlineComment.TypeHintingList',
-          112 => '\'$cm\' does not match next foreach() as variable @Source: moodle.Commenting.InlineComment.TypeHintingFor'));
+          112 => '\'$cm\' does not match next foreach() as variable @Source: moodle.Commenting.InlineComment.TypeHintingFor',
+          118 => 0,
+          122 => 1,
+          124 => 1,
+          126 => 1,
+          128 => 1,
+          130 => 1));
         $this->set_warnings(array(
             4 => 0,
             6 => array(null, 'Commenting.InlineComment.InvalidEndChar'),
@@ -107,7 +113,9 @@ class moodlestandard_testcase extends local_codechecker_testcase {
            71 => 3,
            75 => 2,
            77 => 1,
-           79 => 1));
+           79 => 1,
+          118 => 0,
+          122 => 0));
 
         // Let's do all the hard work!
         $this->verify_cs_results();

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -21,7 +21,7 @@ Feature: Codechecker UI works as expected
       | local/codechecker/version.php           | Well done!                     | Invalid path   |
       | local/codechecker/moodle/tests/fixtures | Files found: 0                 | Invalid path   |
       | local/codechecker/tests/                | local_codechecker_testcase.php | Invalid path   |
-      | local/codechecker/tests/                | Files found: 1                 | Invalid path   |
+      | local/codechecker/tests/                | Files found: 2                 | Invalid path   |
       | local/codechecker/tests/                | Well done!                     | Invalid path   |
       | admin/index.php                         | Files found: 1                 | Invalid path   |
       | admin/index.php                         | Total:                         | Well done!     |

--- a/tests/coverage.php
+++ b/tests/coverage.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Coverage information for the local_codechecker plugin.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+return new class extends phpunit_coverage_info {
+    /** @var array The list of folders relative to the plugin root to include in coverage generation. */
+    protected $includelistfolders = [
+        'classes',
+        'moodle',
+    ];
+
+    /** @var array The list of files relative to the plugin root to include in coverage generation. */
+    protected $includelistfiles = [
+        'locallib.php'];
+
+    /** @var array The list of folders relative to the plugin root to exclude from coverage generation. */
+    protected $excludelistfolders = [
+        'moodle/tests',
+    ];
+
+    /** @var array The list of files relative to the plugin root to exclude from coverage generation. */
+    protected $excludelistfiles = [];
+};


### PR DESCRIPTION
This includes 2 commits:

1. Add the `coverage.php` file for the plugin, so when running with coverage enabled we get info about the files we are interested (keeping apart things like PHPCompatibilty, PHP_CodeSniffer... that are not ours).

2. Add a new sniff that supports the "return new class extends..." anonymous classes.

Important note: This will be failing a number of the checks, because `moodle-plugin-ci` ( that is in charge of checking this) still doesn't know about the new `moodlecheck` and `codechecker` improvements, namely:

- codechecker: Will fail with error in this patch line 19, because it's not aware of the new "return new class extends..." sniff that will allow those phpdoc blocks to exist.
- moodlecheck: Will fail because it's not aware that now we can skip the file phpdoc block when the file is an 1-artifact one (that was recently added to moodlecheck, but it's not yet on moodle-plugin-ci).

That's pretty much the reason we want to release a new `moodle-plugin-ci` version this week, to get all those improvements incorporated.

But if you run codechecker and moodlecheck locally (or via CiBoT)... they all pass:

```
$ phpcs/bin/phpcs --standard=moodle tests/coverage.php && echo "all ok!"
all ok!
```

```
$ php local/moodlecheck/cli/moodlecheck.php -p local/codechecker/tests/coverage.php && echo "all ok!"
all ok!
```