### PR TITLE
Bump highest php version to 8.0 for 311 and master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 7.4
+          - php: 8.0
             moodle-branch: master
             database: pgsql
-          - php: 7.4
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: master
             database: mariadb
-          - php: 7.4
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: MOODLE_311_STABLE
             database: pgsql
-          - php: 7.4
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.0
             moodle-branch: MOODLE_311_STABLE
             database: mariadb
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+
           - php: 7.4
             moodle-branch: MOODLE_310_STABLE
             database: pgsql
@@ -88,6 +101,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
           coverage: none
 
       - name: Initialise moodle-plugin-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,15 @@ cache:
 
 jobs:
   include:
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=master            DB=pgsql
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=master            DB=mysqli
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
-    - php: 7.4
+    - php: 8.0
       env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+
     - php: 7.4
       env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
     - php: 7.4
@@ -60,6 +61,10 @@ jobs:
     # be executed with that PHP versions.
 
 before_install:
+  # The following line is only needed if you're going to run php8 jobs and your
+  # plugin needs xmlrpc services.
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} -gt 7 ]]; then pecl install xmlrpc-beta; fi
+  - echo 'max_input_vars=5000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
@@ -74,17 +79,19 @@ before_install:
     fi
 
 install:
-  - moodle-plugin-ci install
+  # Let's keep phpunit and behat jobs not inited and disabled below until MDL-71622 is sorted out.
+  # (note that, in the mean time GHA will still be running them, so we are covered)
+  - moodle-plugin-ci install --no-init
 
 script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
   - moodle-plugin-ci codechecker
+  - moodle-plugin-ci phpdoc
   - moodle-plugin-ci validate
   - moodle-plugin-ci savepoints
   - moodle-plugin-ci mustache
   - moodle-plugin-ci grunt
-  - moodle-plugin-ci phpdoc
-  - moodle-plugin-ci phpunit
-  - moodle-plugin-ci behat
+  # - moodle-plugin-ci phpunit
+  # - moodle-plugin-ci behat


### PR DESCRIPTION
With core CI tests already passing for PHP 80 (see [the php80 epic](https://tracker.moodle.org/browse/MDL-70745) ), it's time to try it with codechecker.

So, bumping the highest runs of 311 and master from php74 to php80.

Let's see how it goes and if we need to perform any other change...