### PR TITLE
Specify alternative for error_log forbidden function.

### DIFF
--- a/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -59,7 +59,7 @@ class ForbiddenFunctionsSniff extends GenericForbiddenFunctionsSniff {
         // Usual development debugging functions.
         'sizeof'       => 'count',
         'delete'       => 'unset',
-        'error_log'    => null,
+        'error_log'    => 'debugging',
         'print_r'      => null,
         'print_object' => null,
         // Dangerous functions. From coding style.


### PR DESCRIPTION
The question about what function should be used instead of forbidden `error_log` is mentioned in discussion from time to time. This patch is specifying the most approriate replacement.

Related discussion in [MDL-58374](https://tracker.moodle.org/browse/MDL-58374?focusedCommentId=457672&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-457672).