### PR TITLE
Make mariadb:10.5 sticky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.5
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"


### PR DESCRIPTION
New mariadb:10.6 makes the COMPRESSED row format read-only by default
because it's deprecated now and will be removed in mariadb:10.7

This is being tracked @ https://tracker.moodle.org/browse/MDL-72131

Once that issue is fixed and we switch to DYNAMIC or whichever the
final solution is, we'll unpin this.