### PR TITLE
Change test case name to match file and add namespace

### DIFF
--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -14,30 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * This file contains the test cases covering the "moodle" standard.
- *
- * @package    local_codechecker
- * @category   test
- * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace local_codechecker;
 
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../tests/local_codechecker_testcase.php');
 
+// phpcs:disable moodle.NamingConventions
+
 /**
- * PHP CS moodle standard test cases.
+ * Test various "moodle" phpcs standard sniffs.
  *
  * Each case covers one sniff. Self-explanatory
  *
  * To run these tests, you need to use:
  *     vendor/bin/phpunit local/codechecker/moodle/tests/moodlestandard_test.php
  *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
  * @todo Complete coverage of all Sniffs.
  */
-class moodlestandard_testcase extends local_codechecker_testcase {
+class moodlestandard_test extends local_codechecker_testcase {
 
     public function test_psr2_methods_methoddeclaration() {
 

--- a/tests/local_codechecker_testcase.php
+++ b/tests/local_codechecker_testcase.php
@@ -17,14 +17,13 @@
 /**
  * This file contains helper testcase for testing "moodle" CS Sniffs.
  *
- * To run the tests for the Moodle sniffs, you need to use:
- *     vendor/bin/phpunit local/codechecker/moodle/tests/moodlestandard_test.php
- *
  * @package    local_codechecker
  * @category   test
  * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace local_codechecker;
 
 defined('MOODLE_INTERNAL') || die(); // Remove this to use me out from Moodle.
 
@@ -63,19 +62,19 @@ if (class_exists('PHPUnit_Framework_TestCase')) {
     /**
      * Conditional class to keep compatibility between php versions. phpunit <7 alternative.
      */
-    abstract class conditional_PHPUnit_Framework_TestCase extends PHPUnit_Framework_TestCase {
+    abstract class conditional_PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase {
     }
 } else {
     /**
      * Conditional class to keep compatibility between php versions. phpunit >=7 alternative.
      */
-    abstract class conditional_PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
+    abstract class conditional_PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {
     }
 }
 // phpcs:enable
 
 /**
- * Specialized test case for easy testing of "moodle" CS Sniffs.
+ * Specialized test case for easy testing of "moodle" standard sniffs.
  *
  * If you want to run the tests for the Moodle sniffs, you need to
  * use the specific command-line:
@@ -89,6 +88,11 @@ if (class_exists('PHPUnit_Framework_TestCase')) {
  * Should work for any Sniff part of a given standard (custom or core).
  *
  * Note extension & overriding was impossible because of some "final" stuff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class local_codechecker_testcase extends conditional_PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
Following the, more or less, de facto standard (MDL-71049) about
phpunit names and namespace, apply this small changes.

Also removing the file phpdoc block that is not needed any more.

Doing this change now before adding some new utilities and sniffs
that will require a better tests organization.