### PR TITLE
Introduce fixable errors for some sniffs

### DIFF
--- a/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -118,7 +118,14 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
                         '" must be in lower-case letters only';
             }
 
-            $phpcsfile->adderror($error, $stackptr, 'LowercaseMethod');
+            $fix = $phpcsfile->addFixableError($error, $stackptr + 2, 'LowercaseMethod');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $tokens = $phpcsfile->getTokens();
+                $phpcsfile->fixer->replaceToken($stackptr + 2, strtolower($tokens[$stackptr + 2]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
+
             return;
         }
     }
@@ -151,7 +158,14 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
         if (preg_match('/[A-Z]+/', $functionname)) {
             $error = "function name \"$functionname\" must be lower-case letters only";
 
-            $phpcsfile->addError($error, $stackptr, 'LowercaseFunction');
+            $fix = $phpcsfile->addFixableError($error, $stackptr, 'LowercaseFunction');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $tokens = $phpcsfile->getTokens();
+                $phpcsfile->fixer->replaceToken($stackptr + 2, strtolower($tokens[$stackptr + 2]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
+
             return;
         }
     }

--- a/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -52,14 +52,24 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
 
         if (preg_match('/[A-Z]+/', $membername)) {
             $error = "Member variable \"$membername\" must be all lower-case";
-            $phpcsfile->addError($error, $stackptr, 'MemberNameLowerCase');
+            $fix = $phpcsfile->addFixableError($error, $stackptr, 'MemberNameUnderscore');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $phpcsfile->fixer->replaceToken($stackptr, strtolower($tokens[$stackptr]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
         }
 
         // Find underscores in variable names (accepting $_foo for private vars).
         $pos = strpos($membername, '_');
         if ($pos > 1) {
             $error = "Member variable \"$membername\" must not contain underscores.";
-            $phpcsfile->addError($error, $stackptr, 'MemberNameUnderscore');
+            $fix = $phpcsfile->addFixableError($error, $stackptr, 'MemberNameUnderscore');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $phpcsfile->fixer->replaceToken($stackptr, str_replace('_', '', $tokens[$stackptr]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
         }
 
         // Must not be preceded by 'var' keyword.
@@ -118,12 +128,25 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
     private function validate_moodle_variable_name($varname, File $phpcsfile, $stackptr) {
         if (preg_match('/[A-Z]+/', $varname) && !in_array($varname, self::$allowedglobals)) {
             $error = "Variable \"$varname\" must be all lower-case";
-            $phpcsfile->addError($error, $stackptr, 'VariableNameLowerCase');
+            $fix = $phpcsfile->addFixableError($error, $stackptr, 'VariableNameLowerCase');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $tokens = $phpcsfile->getTokens();
+                $phpcsfile->fixer->replaceToken(
+                    $stackptr, str_replace('$' . $varname, '$' . strtolower($varname), $tokens[$stackptr]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
         }
 
         if (strpos($varname, '_') !== false && !in_array($varname, self::$allowedglobals)) {
             $error = "Variable \"$varname\" must not contain underscores.";
-            $phpcsfile->addError($error, $stackptr, 'VariableNameUnderscore');
+            $fix = $phpcsfile->addFixableError($error, $stackptr, 'VariableNameUnderscore');
+            if ($fix === true) {
+                $phpcsfile->fixer->beginChangeset();
+                $tokens = $phpcsfile->getTokens();
+                $phpcsfile->fixer->replaceToken($stackptr, str_replace('_', '', $tokens[$stackptr]['content']));
+                $phpcsfile->fixer->endChangeset();
+            }
         }
     }
 }

--- a/moodle/Sniffs/WhiteSpace/SpaceAfterCommaSniff.php
+++ b/moodle/Sniffs/WhiteSpace/SpaceAfterCommaSniff.php
@@ -45,7 +45,12 @@ class SpaceAfterCommaSniff implements Sniff {
 
         if ($tokens[$stackptr + 1]['code'] !== T_WHITESPACE) {
             $error = 'Commas (,) must be followed by white space.';
-            $file->addError($error, $stackptr, 'NoSpace');
+            $fix = $file->addFixableError($error, $stackptr, 'NoSpace');
+            if ($fix === true) {
+                $file->fixer->beginChangeset();
+                $file->fixer->addContent($stackptr, ' ');
+                $file->fixer->endChangeset();
+            }
         }
     }
 }

--- a/moodle/tests/fixtures/moodle_namingconventions_variablename.php
+++ b/moodle/tests/fixtures/moodle_namingconventions_variablename.php
@@ -17,7 +17,7 @@ class foo {
     var $badvarusage = null;
 }
 
-$result = "String: $badPlaceholder1";
+$result = "String: $badPlaceholder1 is a badPlaceholder1";
 $result = "String: $bad_placeholder2";
 $result = "String: $REALLY_badplaceholder3";
 $result = "String: $goodplaceholder1";

--- a/moodle/tests/fixtures/moodle_namingconventions_variablename.php.fixed
+++ b/moodle/tests/fixtures/moodle_namingconventions_variablename.php.fixed
@@ -1,0 +1,23 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+$badvariable1 = 0;
+$badvariable2 = 0;
+$badvariable3 = 0;
+$reallybadvar4 = 0;
+$goodvariable = 1;
+$ACCESSLIB_PRIVATE = null;
+
+class foo {
+    public $badvariable = null;
+    public $badvariable = null;
+    public $reallybadvar = null;
+    public $goodvariable = null;
+    private $_goodvariable = null;
+    var $badvarusage = null;
+}
+
+$result = "String: $badplaceholder1 is a badPlaceholder1";
+$result = "String: $badplaceholder2";
+$result = "String: $reallybadplaceholder3";
+$result = "String: $goodplaceholder1";


### PR DESCRIPTION
For some simple sniffs, I think it makes sense to register them as fixable errors so phpcbf can automatically fix them. This patch introduces such fixes for:

- Variable names
- Method names
- Spaces between commas