### PR TITLE
Make the fixer able to fix testcase name to match file name

### DIFF
--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -161,8 +161,14 @@ class TestCaseNamesSniff implements Sniff {
         // Check if the file name and the class name match, warn if not.
         $baseName = pathinfo($fileName, PATHINFO_FILENAME);
         if ($baseName !== $class) {
-            $file->addWarning('PHPUnit testcase name "%s" does not match file name "%s"', $cStart,
+            $fix = $file->addFixableWarning('PHPUnit testcase name "%s" does not match file name "%s"', $cStart,
                 'NoMatch', [$class, $baseName]);
+
+            if ($fix === true) {
+                if ($cNameToken = $file->findNext(T_STRING, $cStart + 1, $tokens[$cStart]['scope_opener'])) {
+                    $file->fixer->replaceToken($cNameToken, $baseName);
+                }
+            }
         }
 
         // Check if the class has been already found (this is useful when running against a lot of files).

--- a/moodle/tests/fixtures/phpunit/testcasenames_nomatch.php.fixed
+++ b/moodle/tests/fixtures/phpunit/testcasenames_nomatch.php.fixed
@@ -1,0 +1,11 @@
+<?php
+namespace local_codechecker;
+defined("MOODLE_INTERNAL") || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Correct class but with name not matching the file name.
+ */
+class testcasenames_nomatch extends local_codechecker_testcase {
+    public function test_something() {
+    }
+}


### PR DESCRIPTION
Not much to say, while looking for various different approaches towards getting a bunch of test cases moved to the new policy (see [MDL-71049](https://tracker.moodle.org/browse/MDL-71049) ) I came with this tiny change, so now those class names can be auto-fixed.

Note this doesn't add the namespace or other bits, only the class name, the remaining problems will continue being reported.