### PR TITLE
Verify that sub namespaces in test match the expected location

### DIFF
--- a/moodle/tests/fixtures/phpunit/testcasenames_correct_level2ns.php
+++ b/moodle/tests/fixtures/phpunit/testcasenames_correct_level2ns.php
@@ -1,0 +1,11 @@
+<?php
+namespace local_codechecker\fixtures\phpunit; // Not correct level2, but we aren't checking that. Just correct location.
+defined("MOODLE_INTERNAL") || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Correct class, using correct location matching sub-namespaces.
+ */
+class testcasenames_correct_level2ns extends local_codechecker_testcase {
+    public function test_something() {
+    }
+}

--- a/moodle/tests/fixtures/phpunit/testcasenames_unexpected_level2ns.php
+++ b/moodle/tests/fixtures/phpunit/testcasenames_unexpected_level2ns.php
@@ -1,0 +1,11 @@
+<?php
+namespace local_codechecker\level2\level3;
+defined("MOODLE_INTERNAL") || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Correct class, just the namespace level2 and level3 don't correspond with the expected location.
+ */
+class testcasenames_unexpected_level2ns extends local_codechecker_testcase {
+    public function test_something() {
+    }
+}

--- a/moodle/tests/phpunit_testcasenames_test.php
+++ b/moodle/tests/phpunit_testcasenames_test.php
@@ -71,6 +71,22 @@ class phpunit_testcasenames_test extends local_codechecker_testcase {
                 ],
                 'warnings' => [],
             ],
+            'UnexpectedLevel2NS' => [
+                'fixture' => 'fixtures/phpunit/testcasenames_unexpected_level2ns.php',
+                'errors' => [
+                    8 => 1,
+                ],
+                'warnings' => [
+                    2 => 'does not match its expected location at "tests/level2/level3"'
+                ],
+            ],
+            'CorrectLevel2NS' => [
+                'fixture' => 'fixtures/phpunit/testcasenames_correct_level2ns.php',
+                'errors' => [
+                    8 => 1,
+                ],
+                'warnings' => [],
+            ],
             'MissingNS' => [
                 'fixture' => 'fixtures/phpunit/testcasenames_missing_ns.php',
                 'errors' => [

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -42,7 +42,7 @@ Feature: Codechecker UI works as expected
       | path                            | exclude            | seen                          | notseen      |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 3                | Invalid path |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | moodlestandard_test.php       | Invalid path |
-      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 28               | Invalid path |
+      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 30               | Invalid path |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Line 1 of the opening comment | moodle_php   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |


### PR DESCRIPTION
Added one more check to the unit tests naming sniff that now
verify, for testcase classes, that they are in the expected
subdirectory, following the general namespace rules for stuff
under the "classes" directory.

Note that we still aren't checking the correctness under "classes"
and, once that's implemented, surely some code here will be moved
to the general namespaces sniff (a note about that has been added
to code).

Also, note that we aren't still checking for level2 correctness, that
must be a valid API or "local", whenever that's possible it will be
checked.

So, this only validates that the location (sub-directories) of the
file matches the sub-namespaces of the class.

Covered with tests.