### PR TITLE
Use Generic.Classes.OpeningBraceSameLine sniff

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -10,6 +10,7 @@
     <arg name="encoding" value="utf-8" />
 
     <rule ref="Generic.Classes.DuplicateClassName"/>
+    <rule ref="Generic.Classes.OpeningBraceSameLine"/>
 
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>

--- a/moodle/tests/fixtures/generic_classes_openingclassbrace.php
+++ b/moodle/tests/fixtures/generic_classes_openingclassbrace.php
@@ -1,0 +1,31 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// ONE space before curly bracket is mandatory.
+class test01{
+}
+
+class test02 extends test01{
+}
+
+class test03   {
+}
+
+class test04 extends test01   {
+}
+
+// New line curly bracket is a viloation
+class test05
+{
+}
+
+// These are correct.
+class test06 {
+}
+
+class test07 {}
+
+class test08 extends test06 {
+}
+
+class test09 extends test06 {}

--- a/moodle/tests/moodlestandard_test.php
+++ b/moodle/tests/moodlestandard_test.php
@@ -286,6 +286,31 @@ class moodlestandard_test extends local_codechecker_testcase {
         $this->verify_cs_results();
     }
 
+    public function test_generic_classes_openingclassbrace() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('Generic.Classes.OpeningBraceSameLine');
+        $this->set_fixture(__DIR__ . '/fixtures/generic_classes_openingclassbrace.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors([
+            5 => 'Expected 1 space before opening brace; found 0',
+            8 => 'Expected 1 space before opening brace; found 0',
+            11 => 'Expected 1 space before opening brace; found 3',
+            14 => 'Expected 1 space before opening brace; found 3',
+            19 => 'Opening brace should be on the same line as the declaration for class test05',
+        ]);
+
+        $this->set_warnings([]);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
     public function test_generic_whitespace_scopeindent() {
 
         // Define the standard, sniff and fixture to use.

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -42,7 +42,7 @@ Feature: Codechecker UI works as expected
       | path                            | exclude            | seen                          | notseen      |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 3                | Invalid path |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | moodlestandard_test.php       | Invalid path |
-      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 30               | Invalid path |
+      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 31               | Invalid path |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Line 1 of the opening comment | moodle_php   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |


### PR DESCRIPTION
This implmements validation of use of curly braces in class declaration.

Fixes #168