### PR TITLE
Downgrade to warning the new MoodleInternalNotNeeded error

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Privacy Subsystem implementation for local_codechecker.
- *
- * @package    local_codechecker
- * @copyright  2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace local_codechecker\privacy;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Privacy Subsystem for local_codechecker implementing null_provider.
  *
+ * @package    local_codechecker
  * @copyright  2018 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -122,7 +122,7 @@ class MoodleInternalSniff implements Sniff {
 
         // Having MOODLE_INTERNAL, not having side effects and not having multiple artifacts, error.
         if ($hasMoodleInternal && !$hasSideEffects && !$hasMultipleArtifacts) {
-            $file->addError('Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.',
+            $file->addWarning('Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.',
                 $pointer, 'MoodleInternalNotNeeded');
             return;
         }

--- a/moodle/tests/files_moodleinternal_test.php
+++ b/moodle/tests/files_moodleinternal_test.php
@@ -174,10 +174,10 @@ class files_moodleinternal_test extends local_codechecker_testcase {
         $this->set_sniff('moodle.Files.MoodleInternal');
         $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/unexpected.php');
 
-        $this->set_errors([
+        $this->set_errors([]);
+        $this->set_warnings([
             17 => 'MoodleInternalNotNeeded'
         ]);
-        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }

--- a/renderer.php
+++ b/renderer.php
@@ -15,19 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Code checker renderers.
- *
- * @package    local_codechecker
- * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die;
-
-
-/**
  * Renderer for displaying code-checker reports as HTML.
  *
+ * @package    local_codechecker
  * @copyright  2011 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */


### PR DESCRIPTION
When the new detection was planned at #152, it was agreed
to make it a warning, not an error.

Instead, I missed that completely and implemented it as error.

So, this simple PR just downgrades the check to warning, as
originally planned.

With this patch applied, this will be the behavior:
- Only files having side effects (changing global state) do *require* (error) the MOODLE_INTERNAL check to be added.
- Files without side effects but having multiple artifacts (classes, interfaces and traits) "recommend" (warn) the MOODLE_INTERNAL check to be added.
- Any other file without side effects "recommend" (warn) the MOODLE_INTERNAL check to be removed.

That behavior matches the agreement @ https://tracker.moodle.org/browse/MDLSITE-5967 plus add the new/remaining warning about unexpected MOODLE_INTERNAL checks.