### PR TITLE
Avoid comma-separated use statements to require MOODLE_INTERNAL

### DIFF
--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -154,7 +154,7 @@ class MoodleInternalSniff implements Sniff {
             $pointer = $file->findNext($ignoredtokens, $pointer, null, true);
             if ($tokens[$pointer]['code'] === T_NAMESPACE || $tokens[$pointer]['code'] === T_USE) {
                 // Namespace definitions are allowed before anything else, jump to end of namspace statement.
-                $pointer = $file->findEndOfStatement($pointer + 1);
+                $pointer = $file->findEndOfStatement($pointer + 1, T_COMMA);
             } else if ($tokens[$pointer]['code'] === T_STRING && $tokens[$pointer]['content'] == 'define') {
                 // Some things like AJAX_SCRIPT NO_MOODLE_COOKIES need to be defined before config inclusion.
                 // Jump to end of define().
@@ -320,6 +320,7 @@ class MoodleInternalSniff implements Sniff {
             if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                 continue;
             }
+
 
             // Ignore function/class prefixes.
             if (isset(Tokens::$methodPrefixes[$tokens[$i]['code']]) === true) {

--- a/moodle/tests/fixtures/files/moodleinternal/namespace_with_use_ok.php
+++ b/moodle/tests/fixtures/files/moodleinternal/namespace_with_use_ok.php
@@ -24,6 +24,9 @@
 namespace mod_workshop\plugininfo;
 
 use core\plugininfo\base;
+use core\plugininfo\this,
+    core\plugininfo\that;
+use core\plugininfo\one, core\plugininfo\two,core\plugininfo\three;
 
 class workshopallocation extends base {
     public function is_uninstall_allowed() {


### PR DESCRIPTION
No matter that comma-separated use statements are a violation of
the coding style (see Namespaces section), they, for sure, don't
constitute a side-effect at all, so the MOODLE_INTERNAL check
should be immune to them.

This fix just enables comma-separated to be properly processed,
covered with tests.

Fixes #175