### PR TITLE
Optionaly output PHPCS standard that caused the problem in UI

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,6 +40,7 @@ require_once($CFG->dirroot . '/local/codechecker/locallib.php');
 $pathlist = optional_param('path', '', PARAM_RAW);
 $exclude = optional_param('exclude', '', PARAM_NOTAGS);
 $includewarnings = optional_param('includewarnings', true, PARAM_BOOL);
+$showstandard = optional_param('showstandard', false, PARAM_BOOL);
 
 $pageparams = array();
 if ($pathlist) {
@@ -49,6 +50,7 @@ if ($exclude) {
     $pageparams['exclude'] = $exclude;
 }
 $pageparams['includewarnings'] = $includewarnings;
+$pageparams['showstandard'] = $showstandard;
 
 admin_externalpage_setup('local_codechecker', '', $pageparams);
 
@@ -112,7 +114,7 @@ if ($pathlist) {
         list($numerrors, $numwarnings) = local_codechecker_count_problems($xml);
 
         // Output the results report.
-        echo $output->report($xml, $numerrors, $numwarnings);
+        echo $output->report($xml, $numerrors, $numwarnings, $showstandard);
 
         // And clean the report temp file.
         @unlink($reportfile);

--- a/lang/en/local_codechecker.php
+++ b/lang/en/local_codechecker.php
@@ -58,6 +58,7 @@ $string['path'] = 'Path(s) to check';
 $string['privacy:metadata'] = 'The Code checker plugin does not store any personal data.';
 $string['pluginname'] = 'Code checker';
 $string['recheckfile'] = 'Re-check just this file';
+$string['showstandard'] = 'Display phpcs standard associated with a problem';
 $string['success'] = 'Well done!';
 $string['summary'] = 'Total: {$a}';
 $string['wholefile'] = 'File';

--- a/locallib.php
+++ b/locallib.php
@@ -67,6 +67,10 @@ class local_codechecker_form extends moodleform {
         $mform->addElement('advcheckbox', 'includewarnings', get_string('includewarnings', 'local_codechecker'));
         $mform->setType('includewarnings', PARAM_BOOL);
 
+        $mform->addElement('advcheckbox', 'showstandard', get_string('showstandard', 'local_codechecker'));
+        $mform->setType('showstandard', PARAM_BOOL);
+        $mform->setDefault('showstandard', false);
+
         $mform->addElement('submit', 'submitbutton', get_string('check', 'local_codechecker'));
     }
 }

--- a/renderer.php
+++ b/renderer.php
@@ -22,6 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class local_codechecker_renderer extends plugin_renderer_base {
+    /** @var bool show phpsc standard flag. */
+    private $showstandard;
+
     /** @var array string replaces used to clean up the input line for display. */
     protected $replaces = array(
         "\t" => '<span>&#x25b6;</span>',
@@ -92,9 +95,11 @@ class local_codechecker_renderer extends plugin_renderer_base {
      * @param SimpleXMLElement $xml structure containing all the information to be rendered.
      * @param int $numerrors total number of error-level violations in the run.
      * @param int $numwarnings total number of warning-level violations in the run.
+     * @param bool $showstandard Show phpcs standard associated with problem.
      * @return string the report html
      */
-    public function report(SimpleXMLElement $xml, $numerrors, $numwarnings) {
+    public function report(SimpleXMLElement $xml, $numerrors, $numwarnings, $showstandard = false) {
+        $this->showstandard = $showstandard;
 
         $grandsummary = '';
         $grandtype = '';
@@ -211,6 +216,9 @@ class local_codechecker_renderer extends plugin_renderer_base {
         }
 
         $sourceclass = str_replace('.', '_', $problem['source']);
+        if ($this->showstandard) {
+            $problem = (string) $problem . ' (' . $problem['source'] . ')';
+        }
         $info = html_writer::tag('div', s($problem), array('class' => 'info ' . $sourceclass));
 
         return $code .  html_writer::tag('li', $info, array('class' => 'fail ' . $level));

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -8,25 +8,23 @@ Feature: Codechecker UI works as expected
     Given I log in as "admin"
     And I navigate to "Development > Code checker" in site administration
     And I set the field "Path(s) to check" to "<path>"
-    And I set the field "Exclude" to "*/tests/fixtures/*"
     When I press "Check code"
     Then I should see "<seen>"
     And I should not see "<notseen>"
     And I log out
 
     Examples:
-      | path                                    | seen                           | notseen        |
-      | index.php                               | Files found: 1                 | Invalid path   |
-      | index2.php                              | Invalid path index2.php        | Files found: 1 |
-      | local/codechecker/version.php           | Well done!                     | Invalid path   |
-      | local/codechecker/moodle/tests/fixtures | Files found: 0                 | Invalid path   |
-      | local/codechecker/tests/                | local_codechecker_testcase.php | Invalid path   |
-      | local/codechecker/tests/                | Files found: 2                 | Invalid path   |
-      | local/codechecker/tests/                | Well done!                     | Invalid path   |
-      | admin/index.php                         | Files found: 1                 | Invalid path   |
-      | admin/index.php                         | Total:                         | Well done!     |
-      | admin/index.php                         | Expected 1 space before        | Well done!     |
-      | admin/index.php                         | Inline comments must start     | Well done!     |
+      | path                                                                     | seen                               | notseen        |
+      | index.php                                                                | Files found: 1                     | Invalid path   |
+      | index2.php                                                               | Invalid path index2.php            | Files found: 1 |
+      | local/codechecker/version.php                                            | Well done!                         | Invalid path   |
+      | local/codechecker/tests/                                                 | local_codechecker_testcase.php     | Invalid path   |
+      | local/codechecker/tests/                                                 | Files found: 2                     | Invalid path   |
+      | local/codechecker/tests/                                                 | Well done!                         | Invalid path   |
+      | local/codechecker/moodle/tests/fixtures/files/moodleinternal/problem.php | Files found: 1                     | Invalid path   |
+      | local/codechecker/moodle/tests/fixtures/files/moodleinternal/problem.php | Total: 2 error(s) and 1 warning(s) | Well done!     |
+      | local/codechecker/moodle/tests/fixtures/files/moodleinternal/problem.php | Inline comments must end           | Well done!     |
+      | local/codechecker/moodle/tests/fixtures/files/moodleinternal/problem.php | Expected MOODLE_INTERNAL check     | Well done!     |
 
   Scenario Outline: Verify that specified exclusions are performed
     Given I log in as "admin"
@@ -76,3 +74,15 @@ Feature: Codechecker UI works as expected
     When I press "Check code"
     Then I should see "index.php"
     And I should see "version.php"
+
+  Scenario: Optionally output PHPCS standard
+    Given I log in as "admin"
+    And I navigate to "Development > Code checker" in site administration
+    And I set the field "Path(s) to check" to "local/codechecker/moodle/tests/fixtures/files/moodleinternal/problem.php"
+    And I set the field "Display phpcs standard associated with a problem" to "1"
+    When I press "Check code"
+    Then I should see "moodle.Files.BoilerplateComment.WrongWhitespace"
+    And I set the field "Display phpcs standard associated with a problem" to "0"
+    And I press "Check code"
+    And I should not see "moodle.Files.BoilerplateComment.WrongWhitespace"
+    And I log out


### PR DESCRIPTION
This is tiny UI improvement to optionally (not checked by default) show the coding standard cause the issue (which will be appended to the message):

![image](https://user-images.githubusercontent.com/329780/150800527-95e3de5d-7c4c-4862-a743-701cfac0657f.png)
