### PR TITLE
Apply sensible default values for $CFG if not specified

### DIFF
--- a/moodle/Util/MoodleUtil.php
+++ b/moodle/Util/MoodleUtil.php
@@ -67,14 +67,18 @@ abstract class MoodleUtil {
         defined('IGNORE_COMPONENT_CACHE') ?: define('IGNORE_COMPONENT_CACHE', 1);
         defined('MOODLE_INTERNAL') ?: define('MOODLE_INTERNAL', 1);
 
+        if (!isset($CFG->dirroot)) { // No defined, let's start from scratch.
+            $CFG = (object) [
+                'dirroot' => $moodleRoot,
+                'libdir' => "${moodleRoot}/lib",
+                'admin' => 'admin',
+            ];
+        }
+
         // Save current CFG values.
         $olddirroot = $CFG->dirroot ?? null;
         $oldlibdir = $CFG->libdir ?? null;
         $oldadmin = $CFG->admin ?? null;
-
-        if (!isset($CFG->dirroot)) { // No defined, let's start from scratch.
-            $CFG = new \stdClass();
-        }
 
         if ($CFG->dirroot !== $moodleRoot) { // Different, set the minimum required.
             $CFG->dirroot = $moodleRoot;


### PR DESCRIPTION
In order to use the core_component functions, sensible defaults are
required.

These sensible defaults are available, but the check of `$CFG->dirroot`
when $CFG is empty lead to a php warning, causing phpcs failures.

Even if this error is fixed, the default values in $CFG are then set to
NULL after including core_component, which means that uses of it work
with null values and cause require errors.

Fixes #184