### PR TITLE
Add installation via Composer for phpcs rulesets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+composer.lock

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ We hope you find this tool useful. Please feel free to enhance it.
 Report any idea or bug in [the Tracker](https://tracker.moodle.org/issues/?jql=project%20%3D%20CONTRIB%20AND%20component%20%3D%20%22Local%3A+Code+checker%22), thanks!
 
 
+## Composer installation
+
+1. Install via composer:
+```
+composer global require moodlehq/moodle-local_codechecker
+```
+
+This will install the correct version of phpcs, with the Moodle rules installed, and install the rules.
+
+You can set the Moodle standard as the system default:
+```
+phpcs --config-set default_standard moodle
+```
+
+This will inform most IDEs automatically.
+
+
 IDE Integration
 ---------------
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "moodlehq/moodle-local_codechecker",
+    "type": "phpcodesniffer-standard",
+    "description": "The Moodle coding standard",
+    "keywords": [
+      "phpcs",
+      "standards",
+      "code review",
+      "moodle"
+    ],
+    "license": "GPL-2.0-or-later",
+    "config": {
+      "allow-plugins": {
+        "dealerdirect/phpcodesniffer-composer-installer": true
+      },
+      "sort-packages": true
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2"
+    },
+    "scripts": {
+        "install-codestandards": [
+            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+        ]
+    },
+    "require": {
+        "squizlabs/php_codesniffer": "^3.6.2"
+    }
+}

--- a/moodle/Util/MoodleUtil.php
+++ b/moodle/Util/MoodleUtil.php
@@ -67,14 +67,18 @@ abstract class MoodleUtil {
         defined('IGNORE_COMPONENT_CACHE') ?: define('IGNORE_COMPONENT_CACHE', 1);
         defined('MOODLE_INTERNAL') ?: define('MOODLE_INTERNAL', 1);
 
+        if (!isset($CFG->dirroot)) { // No defined, let's start from scratch.
+            $CFG = (object) [
+                'dirroot' => $moodleRoot,
+                'libdir' => "${moodleRoot}/lib",
+                'admin' => 'admin',
+            ];
+        }
+
         // Save current CFG values.
         $olddirroot = $CFG->dirroot ?? null;
         $oldlibdir = $CFG->libdir ?? null;
         $oldadmin = $CFG->admin ?? null;
-
-        if (!isset($CFG->dirroot)) { // No defined, let's start from scratch.
-            $CFG = new \stdClass();
-        }
 
         if ($CFG->dirroot !== $moodleRoot) { // Different, set the minimum required.
             $CFG->dirroot = $moodleRoot;


### PR DESCRIPTION
I wanted to use this more easily with phpcs.

I've gone for a global version of phpcs, rather than our packaged one, and I've included a dependency to automatically install it in the phpcs configuration.

To use:

```
composer global require moodlehq/moodle-local_codechecker
```

This will automatically install all requirements, and configure our codechecker in the list of phpcs paths.

You can also specify the Moodle standard as the default.
```
phpcs --config-set default_standard moodle
```

I've further extended this in my own repository to set certain opinionated "Best Practices": https://packagist.org/packages/andrewnicols/moodlebestpractice