### PR TITLE
No relevant files

### DIFF
--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -80,6 +80,10 @@ class MoodleInternalSniff implements Sniff {
 
         // Find where real code is and check from there.
         $pointer = $this->get_position_of_relevant_code($file, $pointer);
+        if (!$pointer) {
+            // The file only contains non-relevant (and non side-effects) code. We are done.
+            return;
+        }
 
         if ($this->is_config_php_incluson($file, $pointer)) {
             // We are requiring config.php. This file is good, hurrah!
@@ -136,8 +140,8 @@ class MoodleInternalSniff implements Sniff {
     }
 
     /**
-     * Finds the position of the first bit of relevant code (ignoring namespaces
-     * and define statements).
+     * Finds the position of the first bit of relevant code (ignoring namespaces,
+     * uses, declares and define statements).
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -43,6 +43,8 @@
 
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
 

--- a/moodle/tests/files_moodleinternal_test.php
+++ b/moodle/tests/files_moodleinternal_test.php
@@ -168,8 +168,20 @@ class files_moodleinternal_test extends local_codechecker_testcase {
         $this->verify_cs_results();
     }
 
+    public function test_moodle_files_moodleinternal_no_relevant_ok() {
+        // Files that only contain non-relevant (and no side-effects) code.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/no_relevant_ok.php');
+
+        $this->set_errors([]);
+        $this->set_warnings([]);
+
+        $this->verify_cs_results();
+    }
+
     public function test_moodle_files_moodleinternal_unexpected() {
-        // Old style if statement MOODLE_INTERNAL check.
+        // Unexpected (not needed) check.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.MoodleInternal');
         $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/unexpected.php');

--- a/moodle/tests/fixtures/files/moodleinternal/no_relevant_ok.php
+++ b/moodle/tests/fixtures/files/moodleinternal/no_relevant_ok.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A file that only contains non-relevant (and no side effects) code.
+ */
+
+declare(strict_types=1);
+declare(encoding='UTF-8');
+declare(ticks=1);
+
+namespace local_codechecker;;
+
+use something;
+use various, things;
+use something as elsething;
+
+define('ONE', 1);
+define('TWO', 2);

--- a/moodle/tests/fixtures/squiz_arrays_arraybracketspacing.php
+++ b/moodle/tests/fixtures/squiz_arrays_arraybracketspacing.php
@@ -1,0 +1,37 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+$arr['ok']          = $value;
+$arr ['wrong']      = $value;
+$arr[ 'wrong' ]     = $value;
+
+$array = [ 'foo' => 'bar', 'bar' => 'foo', ];
+
+$array = [
+    'foo' => 'bar',
+    'bar' => 'foo',
+];
+
+if ($arr[($index + 1)] === true) {
+    ok();
+}
+if ($array  [ ($index + 1) ] === true) {
+    wrong();
+}
+
+$a[$a, $b] = $c;
+$a[ $a, $b ] = $c;
+
+echo foo()['ok'];
+echo foo()[ 'wrong' ];
+
+echo $this->arr['ok'];
+echo $this->arr[ 'wrong' ];
+
+echo [ 1, 2, 3 ]['ok'];
+echo [ 1, 2, 3 ][ 'wrong' ];
+
+echo 'PHP'['ok'];
+echo 'PHP'[ 'wrong' ];
+
+$arr = [];
+$arr = [ ];

--- a/moodle/tests/fixtures/squiz_arrays_arraybracketspacing.php.fixed
+++ b/moodle/tests/fixtures/squiz_arrays_arraybracketspacing.php.fixed
@@ -1,0 +1,37 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+$arr['ok']          = $value;
+$arr['wrong']      = $value;
+$arr['wrong']     = $value;
+
+$array = [ 'foo' => 'bar', 'bar' => 'foo', ];
+
+$array = [
+    'foo' => 'bar',
+    'bar' => 'foo',
+];
+
+if ($arr[($index + 1)] === true) {
+    ok();
+}
+if ($array[($index + 1)] === true) {
+    wrong();
+}
+
+$a[$a, $b] = $c;
+$a[$a, $b] = $c;
+
+echo foo()['ok'];
+echo foo()['wrong'];
+
+echo $this->arr['ok'];
+echo $this->arr['wrong'];
+
+echo [ 1, 2, 3 ]['ok'];
+echo [ 1, 2, 3 ]['wrong'];
+
+echo 'PHP'['ok'];
+echo 'PHP'['wrong'];
+
+$arr = [];
+$arr = [ ];

--- a/moodle/tests/squiz_arrays_arraybracketspacing_test.php
+++ b/moodle/tests/squiz_arrays_arraybracketspacing_test.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_codechecker;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../../tests/local_codechecker_testcase.php');
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff sniff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
+ */
+class squiz_arrays_arraybracketspacing_test extends local_codechecker_testcase {
+
+    /**
+     * Test the Squid.Arrays.ArrayBracketSpacing sniff
+     */
+    public function test_squiz_arrays_arraybracketspacing() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('Squiz.Arrays.ArrayBracketSpacing');
+        $this->set_fixture(__DIR__ . '/fixtures/squiz_arrays_arraybracketspacing.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors([
+            4 => "expected \"\$arr[\" but found \"\$arr [\"",
+            5 => ["expected \"['wrong'\" but found \"[ 'wrong'\"", "expected \"'wrong']\" but found \"'wrong' ]\""],
+            17 => 3,
+            22 => 2,
+            25 => 2,
+            28 => 2,
+            31 => 2,
+            34 => 2,
+        ]);
+        $this->set_warnings([]);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -40,7 +40,7 @@ Feature: Codechecker UI works as expected
       | path                            | exclude            | seen                          | notseen      |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 8                | Invalid path |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | moodlestandard_test.php       | Invalid path |
-      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 69               | Invalid path |
+      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 70               | Invalid path |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Line 1 of the opening comment | moodle_php   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |

--- a/tests/behat/ui.feature
+++ b/tests/behat/ui.feature
@@ -38,9 +38,9 @@ Feature: Codechecker UI works as expected
 
     Examples:
       | path                            | exclude            | seen                          | notseen      |
-      | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 7                | Invalid path |
+      | local/codechecker/moodle/tests  | */tests/fixtures/* | Files found: 8                | Invalid path |
       | local/codechecker/moodle/tests  | */tests/fixtures/* | moodlestandard_test.php       | Invalid path |
-      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 67               | Invalid path |
+      | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Files found: 69               | Invalid path |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Line 1 of the opening comment | moodle_php   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |
       | local/codechecker/moodle/tests/ | *PHPC*, *moodle_*  | Inline comments must end      | /phpcompat   |


### PR DESCRIPTION
Files containing exclusively non-relevant code are ok
    
As far as all the non-relevant code (namespace, uses, declare and
defines) is also code without side effects, these files don't need
the MOODLE_INTERNAL check).
    
Covered with tests.
    
This needs to be merged after #190.
    
Fixes #188