### PR TITLE
Unpin MariaDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"


### PR DESCRIPTION
Once the new 10.6.7 and 10.7.3 docker images are available
we can unpin MariaDB in all our repos.

Note the images are not yet available (as of Feb 25 2022), but I
wanted to verify one little thing with the current versions.

Fixes #150