### PR TITLE
Update links to the coding style docs to the new dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Information
 -----------
 
 This Moodle plugin uses the [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) tool to
-check that code follows the [Moodle coding style](http://docs.moodle.org/dev/Coding_style). It uses the [Moodle Coding Style](https://github.com/moodlehq/moodle-cs) 'sniffs' that check many aspects of the code, including the awesome [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ones.
+check that code follows the [Moodle coding style](https://moodledev.io/general/development/policies/codingstyle).
+It uses the [Moodle Coding Style](https://github.com/moodlehq/moodle-cs) 'sniffs' that check many aspects of the code, including the awesome
+[PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) ones.
 
 It was created by developers at the Open University, including Sam Marshall,
 Tim Hunt and Jenny Gray. It is now maintained by Moodle HQ.

--- a/locallib.php
+++ b/locallib.php
@@ -50,7 +50,7 @@ class local_codechecker_form extends moodleform {
         $mform = $this->_form;
 
         $a = new stdClass();
-        $a->link = html_writer::link('http://docs.moodle.org/dev/Coding_style',
+        $a->link = html_writer::link('https://moodledev.io/general/development/policies/codingstyle',
                 get_string('moodlecodingguidelines', 'local_codechecker'));
         $a->path = html_writer::tag('tt', 'local/codechecker');
         $a->excludeexample = html_writer::tag('tt', 'db, backup/*1, *lib*');


### PR DESCRIPTION
Just spotted this while debugging something else. Hopefully this is a useful change.