### PR TITLE
Shortcut core's .phpcs.xml by adding our own one

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="moodle" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+  <rule ref="MoodleCS/moodle"/>
+</ruleset>


### PR DESCRIPTION
Some problems are happening with core's phpcs.xml configuration, because it points to the "moodle" standard and that, as directory, doesn't exist anymore in codechecker (it's an alias now).

But it's an alias that only works under unix environments, now windows.

So we are adding our own phpcs.xml file, pointing to the correct standard. That will, automatically, stop phpcs to continue looking upwards.

See #207 for more detailed information about why core phpcs.xml is interfering in local_codechecker and, specifically, breaking under windows.

Fixes #207