### PR TITLE
Enable php81 tests for 401_STABLE and master (4.2dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,15 @@ jobs:
           - php: 8.1
             moodle-branch: master
             database: pgsql
+            plugin-ci: dev-master
           - php: 8.1
             moodle-branch: master
             database: mariadb
+            plugin-ci: dev-master
           - php: 8.1
             moodle-branch: MOODLE_401_STABLE
             database: pgsql
+            plugin-ci: dev-master
 
           - php: 8.0
             moodle-branch: MOODLE_400_STABLE
@@ -107,7 +110,11 @@ jobs:
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          if [ ${{ matrix.plugin-ci }} ]; then
+              composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ${{ matrix.plugin-ci }}
+          else
+              composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          fi
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
       matrix:
         include:
           # Highest php versions supported by each branch (with master always being tested twice).
-          # TODO: Enable when master (4.2dev) supports php81
-          #- php: 8.1
-          #  moodle-branch: master
-          #  database: pgsql
-          #- php: 8.1
-          #  moodle-branch: master
-          #  database: mariadb
-          - php: 8.0
+          - php: 8.1
+            moodle-branch: master
+            database: pgsql
+          - php: 8.1
+            moodle-branch: master
+            database: mariadb
+          - php: 8.1
             moodle-branch: MOODLE_401_STABLE
             database: pgsql
+
           - php: 8.0
             moodle-branch: MOODLE_400_STABLE
             database: pgsql
@@ -73,6 +73,7 @@ jobs:
           - php: 8.0
             moodle-branch: master
             database: mariadb
+
           - php: 7.4
             moodle-branch: MOODLE_401_STABLE
             database: pgsql


### PR DESCRIPTION
This is part of the php81 epic:

https://tracker.moodle.org/browse/MDL-73016

It's near completed and passing in CIs, so let's enable the php81 tests for both MOODLE_401_STABLE and master (4.2dev).

Also, let's use moodle-plugin-ci 4 (dev-master) for php81 runs (to demo how people can keep v3 and v4 working together).

Ciao :-)