### PR TITLE
Bump 402 and master tests from php81 to php82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,16 @@ jobs:
       matrix:
         include:
           # Highest php versions supported by each branch (with master always being tested twice).
-          - php: 8.1
+          - php: 8.2
             moodle-branch: master
             database: pgsql
-          - php: 8.1
+          - php: 8.2
             moodle-branch: master
             database: mariadb
-          - php: 8.1
+          - php: 8.2
             moodle-branch: MOODLE_402_STABLE
             database: pgsql
+
           - php: 8.1
             moodle-branch: MOODLE_401_STABLE
             database: pgsql


### PR DESCRIPTION
With the PHP 8.2 epic (https://tracker.moodle.org/browse/MDL-76405) near being completed, it's time to verify and continuously test that everything is passing with that PHP version.