### PR TITLE
Remove the "moodle" alias after 1 year

### DIFF
--- a/moodle
+++ b/moodle
@@ -1,1 +1,0 @@
-MoodleCS/moodle

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="moodle" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-  <rule ref="MoodleCS/moodle"/>
-</ruleset>

--- a/thirdpartylibs.xml
+++ b/thirdpartylibs.xml
@@ -28,8 +28,4 @@
         <license>GPL</license>
         <licenseversion>3</licenseversion>
     </library>
-    <library>
-        <location>moodle</location>
-        <name>Alias to Moodle Coding Style (to avoid it being inspected)</name>
-    </library>
 </libraries>


### PR DESCRIPTION
After one year since we moved the moodle coding style from local_codechecker to moodle-cs, it's time to perform this small cleanup that was kept to allow old integrations with local_codechecker to continue working.

Now, everybody should be already using moodle-cs, so we can remove those remaining bit:
 - moodle dir alias.
 - phpcs.xml file, needed to shortcut core's one.
 - entry from thirdpartylibs.xml to avoid the moodle dir (alias) to be checked.

Fixes #202.