### PR TITLE
Update Moodle GHA versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,28 +56,6 @@ jobs:
             moodle-branch: MOODLE_401_STABLE
             database: pgsql
 
-          - php: 8.0
-            moodle-branch: MOODLE_400_STABLE
-            database: pgsql
-            # The following line is only needed if you're going to run php8 jobs and your
-            # plugin needs xmlrpc services.
-            extensions: xmlrpc-beta
-          - php: 8.0
-            moodle-branch: MOODLE_311_STABLE
-            database: pgsql
-            # The following line is only needed if you're going to run php8 jobs and your
-            # plugin needs xmlrpc services.
-            extensions: xmlrpc-beta
-
-          - php: 7.4
-            moodle-branch: MOODLE_310_STABLE
-            database: pgsql
-          - php: 7.4
-            moodle-branch: MOODLE_39_STABLE
-            database: pgsql
-          - php: 7.4
-            moodle-branch: MOODLE_38_STABLE
-            database: pgsql
 
           # Lowest php versions supported by each branch (with main always being tested twice).
           - php: 8.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
             moodle-branch: main
             database: mariadb
           - php: 8.3
+            moodle-branch: MOODLE_500_STABLE
+            database: pgsql
+          - php: 8.3
             moodle-branch: MOODLE_405_STABLE
             database: pgsql
           - php: 8.3
@@ -83,6 +86,10 @@ jobs:
           - php: 8.1
             moodle-branch: main
             database: mariadb
+          - php: 8.2
+            moodle-branch: MOODLE_500_STABLE
+            database: pgsql
+
           - php: 8.1
             moodle-branch: MOODLE_405_STABLE
             database: pgsql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
             database: pgsql
 
           # Lowest php versions supported by each branch (with main always being tested twice).
-          - php: 8.1
+          - php: 8.2
             moodle-branch: main
             database: pgsql
-          - php: 8.1
+          - php: 8.2
             moodle-branch: main
             database: mariadb
           - php: 8.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
             moodle-branch: main
             database: mariadb
           - php: 8.3
+            moodle-branch: MOODLE_405_STABLE
+            database: pgsql
+          - php: 8.3
             moodle-branch: MOODLE_404_STABLE
             database: pgsql
 
@@ -80,6 +83,9 @@ jobs:
           - php: 8.1
             moodle-branch: main
             database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_405_STABLE
+            database: pgsql
           - php: 8.1
             moodle-branch: MOODLE_404_STABLE
             database: pgsql


### PR DESCRIPTION
# Changes

- Add MOODLE_405_STABLE GHA tests
- Add MOODLE_500_STABLE GHA tests
- Update the lowest PHP version supported by main
- Remove MOODLE GHA tests for any version before 4.1 LTS (current security release)
